### PR TITLE
fixed time_clip for 1D data

### DIFF
--- a/pyspedas/analysis/time_clip.py
+++ b/pyspedas/analysis/time_clip.py
@@ -131,8 +131,10 @@ def time_clip(names, time_start, time_end, new_names=None, suffix=None):
                 pytplot.store_data(n_names[j], data={'x': time[index_start:index_end], 'y': data[index_start:index_end, :], 'v': v_data})
             elif 'v' in tmp_dquant.coords.keys():
                 pytplot.store_data(n_names[j], data={'x': time[index_start:index_end], 'y': data[index_start:index_end, :], 'v': v_data})
+            elif data.ndim == 1:
+                pytplot.store_data(n_names[j], data={'x': time[index_start:index_end], 'y': data[index_start:index_end]})
             else:
-                pytplot.store_data(n_names[j], data={'x': time[index_start:index_end], 'y': data[index_start:index_end, :]})
+                pytplot.store_data(n_names[j], data={'x': time[index_start:index_end], 'y': data[index_start:index_end,...]})
         except IndexError:
             print('Problem time clipping: ' + n_names[j])
             continue


### PR DESCRIPTION
This fixes errors generated when time_clip=True is used in mms_load_xxx.
For example, the following code generated errors:
```python
from pyspedas import mms_load_fgm
mms_load_fgm(trange=['2015-10-16 12:00:00', '2015-10-16 13:00:00'], time_clip=True)
```
This is probably due to inappropriate treatment of 1D data (i.e., time series of scalars).
