### PR TITLE
CDF time conversion to unix time using astropy instead of cdflib

### DIFF
--- a/.travisreqs.txt
+++ b/.travisreqs.txt
@@ -1,3 +1,4 @@
+astropy
 cdflib
 pytplot
 pyqtgraph

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     project_urls={'Information': 'http://spedas.org/wiki/',
                   },
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    install_requires=['pyqtwebengine', 'pyqt5==5.12', 'requests', 'scipy', 'pytplot>=1.4', 'cdflib', 'msgpack', 'bokeh', 'nodejs',
+    install_requires=['pyqtwebengine', 'pyqt5==5.12', 'requests', 'scipy', 'pytplot>=1.4', 'astropy', 'cdflib', 'msgpack', 'bokeh', 'nodejs',
                       'pyqtgraph', 'numpy', 'pydivide', 'pandas>=0.24'],
     python_requires='>=3.5',
 )


### PR DESCRIPTION
This improves performance for CDF time to unix time conversion originally performed using `cdflib.cdfepoch.unixtime`, which uses python's intrinsic `for` loops for conversion and is way too slow.
Simple testing finds that conversion via astropy is more than ten times faster.
Although this introduces additional module dependency, this will be useful from users' perspective.

Note: cdflib developers seem to be considering the integration of astropy's time module in cdflib.
https://github.com/MAVENSDC/cdflib/issues/14