### PR TITLE
added empy __init__.py

### DIFF
--- a/pyspedas/__init__.py
+++ b/pyspedas/__init__.py
@@ -27,8 +27,8 @@ from .analysis.tinterpol import tinterpol
 from .analysis.subtract_average import subtract_average
 from .analysis.subtract_median import subtract_median
 from .analysis.time_clip import time_clip
-from .spdtplot.cdf_to_tplot import cdf_to_tplot
-from .spdtplot.tplot_names import tplot_names
+from pytplot import cdf_to_tplot
+from pytplot import tplot_names
 
 from .mms import mms_load_mec, mms_load_fgm, mms_load_scm, mms_load_edi, mms_load_edp, mms_load_eis, mms_load_feeps, \
     mms_load_hpca, mms_load_fpi, mms_load_aspoc, mms_load_dsp, mms_load_fsm

--- a/pyspedas/mms/mms_load_data.py
+++ b/pyspedas/mms/mms_load_data.py
@@ -6,7 +6,7 @@ import requests
 import logging
 import warnings
 import numpy as np
-from ..spdtplot.cdf_to_tplot import cdf_to_tplot
+from pytplot import cdf_to_tplot
 from ..analysis.time_clip import time_clip as tclip
 from pyspedas import time_double, time_string
 from dateutil.parser import parse


### PR DESCRIPTION
installation via
```
$ python setup.py install
```
does not copy pyspedas/mms/dsp directory because `__init__.py` is missing.

Adding empty `__init__.py` resolves the issue.