### PR TITLE
Bug fix for mms_load_scm

### DIFF
--- a/pyspedas/mms/__init__.py
+++ b/pyspedas/mms/__init__.py
@@ -417,6 +417,26 @@ def mms_load_scm(trange=['2015-10-16', '2015-10-17'], probe='1', data_rate='srvy
         List of tplot variables created.
 
     """
+    if not isinstance(data_rate, list):
+        data_rate = list([data_rate])
+
+    if isinstance(datatype, str) and datatype == '':
+        # guess from data_rate
+        datatype = list()
+        for dr in data_rate:
+            if dr == 'srvy':
+                datatype.append('scsrvy')
+            if dr == 'brst':
+                datatype.extend(['scb', 'schb'])
+        datatype = list(set(datatype)) # make it unique
+    else:
+        if not isinstance(datatype, list):
+            datatype = list([datatype])
+        # ensure datatype does not contain empty string
+        datatype = list(set([dt.strip() for dt in datatype]))
+        if '' in datatype:
+            datatype.remove('')
+
     tvars = mms_load_data(trange=trange, notplot=notplot, probe=probe, data_rate=data_rate, level=level, instrument='scm',
             datatype=datatype, varformat=varformat, suffix=suffix, get_support_data=get_support_data,
             time_clip=time_clip, no_update=no_update, available=available, latest_version=latest_version, 


### PR DESCRIPTION
The local download directly structure for SCM data is not consistent with SDC and IDL version of spedas. This happens when `datatype` argument is not specified in calling `mms_load_scm`.
I found the problem when downloading burst mode data, but I guess there should be the same problem for the survey mode.

For instance, for `scb` datatype, the correct directory should be
```
MMS_DATA_DIR/mms1/scm/brst/l2/scb/YYYY/MM/DD/
```
whereas the data files are saved to the wrong directry (i.e., 'scb' is missing)
```
MMS_DATA_DIR/mms1/scm/brst/l2/YYYY/MM/DD/
```

The problem should be solved by properly checking the arguments passed to `mms_load_scm` before calling `mms_load_data`.
I am not sure what should be correct behavior, but at least we should pass non-empty `datatype` to `mms_load_data` to preserve the correct directory structure.