### PR TITLE
A few improvements to the load routine

### DIFF
--- a/pyspedas/maven/__init__.py
+++ b/pyspedas/maven/__init__.py
@@ -23,7 +23,8 @@ def maven_load(filenames=None,
                varformat=None,
                prefix='',
                suffix='',
-               get_support_data=False):
+               get_support_data=False,
+               auto_yes=False):
     """
     Main function for downloading MAVEN data and loading it into tplot variables (if CDF or STS data type).
     This function will also load in MAVEN KP data for position information, and read those into tplot as well
@@ -46,8 +47,8 @@ def maven_load(filenames=None,
             LPW                 lpiv, lpnt, mrgscpot, we12, we12burstlf, we12bursthf, we12burstmf, wn, wspecact, wspecpas
             STATIC              2a, c0, c2, c4, c6, c8, ca, cc, cd, ce, cf, d0, d1, d4, d6, d7, d8, d9, da, db
             SEP                 s1-raw-svy-full, s1-cal-svy-full, s2-raw-svy-full, s2-cal-svy-full
-            SWEA                coarsearc3d, coarsesvy3d, finearc3d, finesvy3d, onboardsvymom, onboardsvyspec
-            SWIA                arc3d, arcpad, svy3d, svypad, svyspec
+            SWEA                arc3d, arcpad, svy3d, svypad, svyspec
+            SWIA                coarsearc3d, coarsesvy3d, finearc3d, finesvy3d, onboardsvymom, onboardsvyspec
             MAG                 ss, pc, pl, ss1s, pc1s, pl1s
             =================== =====================================
         level: str
@@ -88,10 +89,13 @@ def maven_load(filenames=None,
             Data with an attribute "VAR_TYPE" with a value of "support_data"
             will be loaded into tplot.  By default, only loads in data with a
             "VAR_TYPE" attribute of "data".
+        auto_yes : bool
+            If this is True, there will be no prompt asking if you'd like to download files.
     """
     tvars = load_data(filenames=filenames, instruments=instruments, level=level, type=type, insitu=insitu, iuvs=iuvs,
                       start_date=start_date, end_date=end_date, update_prefs=update_prefs,
                       only_update_prefs=only_update_prefs, local_dir=local_dir, list_files=list_files,
                       new_files=new_files, exclude_orbit_file=exclude_orbit_file, download_only=download_only,
-                      varformat=varformat, prefix=prefix, suffix=suffix, get_support_data=get_support_data)
+                      varformat=varformat, prefix=prefix, suffix=suffix, get_support_data=get_support_data,
+                      auto_yes=auto_yes)
     return tvars

--- a/pyspedas/maven/download_files_utilities.py
+++ b/pyspedas/maven/download_files_utilities.py
@@ -138,24 +138,9 @@ def get_root_data_dir():
     # Get preferred data download location for pyspedas project
     prefs = pyspedas.get_spedas_prefs()
     if 'data_dir' in prefs:
-        download_path = prefs['data_dir']
+        return prefs['data_dir']
     else:
         raise NameError('data_dir is not found in spd_prefs.txt')
-
-    import os
-    # Get the "toolkit path" (where MAVEN download code is)
-    full_path = os.path.realpath(__file__)
-    toolkit_path = os.path.dirname(full_path)
-    if not os.path.exists(os.path.join(toolkit_path, 'mvn_toolkit_prefs.txt')):
-        create_pref_file(toolkit_path, download_path)
-
-    with open(os.path.join(toolkit_path, 'mvn_toolkit_prefs.txt'), 'r') as f:
-        f.readline()
-        s = f.readline().rstrip()
-        # Get rid of first space
-        s = s.split(' ')
-        nothing = ' '
-    return nothing.join(s[1:])
 
 
 def create_pref_file(toolkit_path, download_path):

--- a/pyspedas/maven/utilities.py
+++ b/pyspedas/maven/utilities.py
@@ -10,67 +10,6 @@ import numpy as np
 import collections
 
 
-def compare_versions():
-    # import libraries
-    import requests
-
-    # access complete list of revision numbers on PyPI
-    pydivide_url = "https://pypi.python.org/pypi/pydivide/json"
-    try:
-        pd_pypi_vn = sorted(requests.get(pydivide_url).json()['releases'])
-    except:
-        return
-
-    # find PyPI version number
-    pd_pypi_vn = pd_pypi_vn[-1]
-    pr1 = pd_pypi_vn
-    pd_pypi_vn = pd_pypi_vn.split(".")
-    # convert to integer array for comparison
-    pd_pypi_vn = [int(i) for i in pd_pypi_vn]
-
-    # find current directory out of which code is executing
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    version_path = dir_path + '/version.txt'
-    # open version.txt in current directory and read
-    with open(version_path) as f:
-        cur_vn = f.readline()
-    cur_vn = "".join(cur_vn)
-    pr2 = cur_vn
-    cur_vn = cur_vn.split(".")
-    # convert to integer array for comparison
-    cur_vn = [int(i) for i in cur_vn]
-
-    # for each item in version number array [X.Y.Z]
-    for i in range(len(cur_vn)):
-        # if current item > PyPI item (hypothetical), break, latest version is running
-        if cur_vn[i] > pd_pypi_vn[i]:
-            old_flag = 0
-            break
-        # if current item = PyPI item, continue to check next item
-        elif cur_vn[i] == pd_pypi_vn[i]:
-            old_flag = 0
-            continue
-        # if current item < PyPI item, indicative of old version, throw flag to initiate warning
-        else:
-            old_flag = 1
-            break
-
-    # if not running latest version, throw warning
-    if old_flag == 1:
-        print("PyPI PyDivide Version")
-        print(pr1)
-        print("Your PyDivide Version in " + dir_path)
-        print(pr2)
-        print("")
-        print('****************************** WARNING! ******************************')
-        print('*                                                                    *')
-        print('*          You are running an outdated version of PyDivide.          *')
-        print('*              Sync your module for the latest updates.              *')
-        print('*                                                                    *')
-        print('****************************** WARNING! ******************************')
-    return
-
-
 def param_list(kp):
     '''
     Return a listing of all parameters present in the given
@@ -1642,14 +1581,10 @@ param_dict = {'Electron Density': 'ELECTRON_DENSITY',
               'Solar Wind Dynamic Pressure': 'SOLAR_WIND_DYNAMIC_PRESSURE',
               'Solar Wind Pressure Quality': 'SOLAR_WIND_DYNAMIC_PRESSURE_QUAL',
               'STATIC Quality Flag': 'STATIC_QUALITY_FLAG',
-              'H+ Density': 'HPLUS_DENSITY',
-              'H+ Density Quality': 'HPLUS_DENSITY_QUAL',
               'O+ Density': 'OPLUS_DENSITY',
               'O+ Density Quality': 'OPLUS_DENSITY_QUAL',
               'O2+ Density': 'O2PLUS_DENSITY',
               'O2+ Density Quality': 'O2PLUS_DENSITY_QUAL',
-              'H+ Temperature': 'HPLUS_TEMPERATURE',
-              'H+ Temperature Quality': 'HPLUS_TEMPERATURE_QUAL',
               'O+ Temperature': 'OPLUS_TEMPERATURE',
               'O+ Temperature Quality': 'OPLUS_TEMPERATURE_QUAL',
               'O2+ Temperature': 'O2PLUS_TEMPERATURE',


### PR DESCRIPTION
-maven_load has an auto_yes flag so the user doesn't have to specify "y" to every download
-maven_load will now properly use the correct pyspedas directory 
-users can now specify "level='kp'" to the maven_load routine to get the key parameter data instead of the l2 data 