### PR TITLE
Add hourly OMNI data

### DIFF
--- a/pyspedas/omni/__init__.py
+++ b/pyspedas/omni/__init__.py
@@ -6,6 +6,7 @@ def data(trange=['2013-11-5', '2013-11-6'],
         level='hro2',
         suffix='',  
         get_support_data=False, 
+        get_ignore_data=False,
         varformat=None,
         varnames=[],
         downloadonly=False,
@@ -25,7 +26,7 @@ def data(trange=['2013-11-5', '2013-11-6'],
             Data level; valid options: hro, hro2
 
         datatype: str
-            Data type; valid options: 1min, 5min
+            Data type; valid options: 1min, 5min, hourly (1 hour)
 
         suffix: str
             The tplot variable names will be given this suffix.  By default, 
@@ -62,6 +63,6 @@ def data(trange=['2013-11-5', '2013-11-6'],
 
     """
     return load(trange=trange, level=level, datatype=datatype, suffix=suffix, 
-                get_support_data=get_support_data, varformat=varformat, 
+                get_support_data=get_support_data, get_ignore_data=get_ignore_data,varformat=varformat, 
                 varnames=varnames, downloadonly=downloadonly, notplot=notplot, 
                 time_clip=time_clip, no_update=no_update)

--- a/pyspedas/omni/load.py
+++ b/pyspedas/omni/load.py
@@ -10,7 +10,8 @@ def load(trange=['2013-11-5', '2013-11-6'],
          datatype='1min',
          level='hro2',
          suffix='', 
-         get_support_data=False, 
+         get_support_data=False,
+         get_ignore_data=False,         
          varformat=None,
          varnames=[],
          downloadonly=False,
@@ -24,7 +25,12 @@ def load(trange=['2013-11-5', '2013-11-6'],
 
     """
 
-    pathformat = level+'_'+datatype+'/%Y/omni_'+level+'_'+datatype+'_%Y%m01_v??.cdf'
+    if 'min' in datatype:
+        pathformat = level + '_' + datatype + '/%Y/omni_' + level + '_' + datatype + '_%Y%m01_v??.cdf'
+    elif 'hour' in datatype:
+        pathformat = 'hourly/%Y/omni2_h0_mrg1hr_%Y%m01_v??.cdf'
+    else:
+        raise TypeError("%r are invalid keyword arguments" % datatype)
 
     # find the full remote path names using the trange
     remote_names = dailynames(file_format=pathformat, trange=trange)
@@ -41,7 +47,7 @@ def load(trange=['2013-11-5', '2013-11-6'],
     if downloadonly:
         return out_files
 
-    tvars = cdf_to_tplot(out_files, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, notplot=notplot)
+    tvars = cdf_to_tplot(out_files, suffix=suffix, get_support_data=get_support_data, get_ignore_data=get_ignore_data, varformat=varformat, varnames=varnames, notplot=notplot)
     
     if notplot:
         return tvars


### PR DESCRIPTION
#### Reference Issures/PRs
None. 
#### What does this implement/fix? Explain your changes.
Add hourly data in datatype to read hourly OMNI data files. 
Add a new keyword 'get_ignore_data' because the hourly OMNI CDF files have only 'ignore_data' instead of 'data' or 'support data'. 
#### Any other comments?
The keyword 'get_ignore_data' has been merged to the pytplot repo. 
