### PR TITLE
Fix: Delete temporary file after download

### DIFF
--- a/pyspedas/utilities/download.py
+++ b/pyspedas/utilities/download.py
@@ -117,6 +117,7 @@ def download_file(url=None, filename=None, headers={}, username=None, password=N
 
     fsrc.close()
     ftmp.close()
+    os.unlink(ftmp.name) # delete the temporary file
     
     logging.info('Download complete: ' + filename)
 


### PR DESCRIPTION
Add a line to delete temporary files after download.
They were not deleted originally, and the hard drive is filled with temp files. 