### PR TITLE
Update load.py of Parker Solar Probe on datatype='sqtn_rfs_v1v2'

### DIFF
--- a/pyspedas/psp/load.py
+++ b/pyspedas/psp/load.py
@@ -63,7 +63,7 @@ def load(trange=['2018-11-5', '2018-11-6'],
                 dtype_tmp = datatype[:11]
                 stype_tmp = datatype[12:]
             pathformat = instrument + '/' + level + '/' + dtype_tmp + '/' + stype_tmp + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v??.cdf'
-        elif datatype['sqtn_rfs_v1v2']:
+        elif datatype == 'sqtn_rfs_v1v2':
             # unfortunately the naming format of quasi-thermal-noise cdf file is different from others
             pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v?.?.cdf'
 

--- a/pyspedas/psp/load.py
+++ b/pyspedas/psp/load.py
@@ -65,7 +65,7 @@ def load(trange=['2018-11-5', '2018-11-6'],
             pathformat = instrument + '/' + level + '/' + dtype_tmp + '/' + stype_tmp + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v??.cdf'
         elif datatype['sqtn_rfs_v1v2']:
             # unfortunately the naming format of quasi-thermal-noise cdf file is different from others
-            pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d%H_v?.?.cdf'
+            pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v?.?.cdf'
 
         else:
             pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d%H_v??.cdf'

--- a/pyspedas/psp/load.py
+++ b/pyspedas/psp/load.py
@@ -63,6 +63,9 @@ def load(trange=['2018-11-5', '2018-11-6'],
                 dtype_tmp = datatype[:11]
                 stype_tmp = datatype[12:]
             pathformat = instrument + '/' + level + '/' + dtype_tmp + '/' + stype_tmp + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v??.cdf'
+        elif datatype['sqtn_rfs_v1v2']:
+            # unfortunately the naming format of quasi-thermal-noise cdf file is different from others
+            pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d%H_v?.?.cdf'
 
         else:
             pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d%H_v??.cdf'


### PR DESCRIPTION
The datatype "sqtn_rfs_v1v2" for psp.fields has different naming pattern from others, i.e. with
'_%Y%m%d_v?.?.cdf'
instead of
'_%Y%m%d_v??.cdf'
The code has been tested successfully with:

```
from pyspedas.utilities.dailynames import dailynames
from pyspedas.utilities.download import download
from pyspedas.analysis.time_clip import time_clip as tclip
from pytplot import cdf_to_tplot

instrument = 'fields'
level='l3'
datatype='sqtn_rfs_v1v2'

pathformat=instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v?.?.cdf'

trange=['2018-11-01', '2018-12-6']
file_resolution = 24*3600
remote_names = dailynames(file_format=pathformat, trange=trange, res=file_resolution)

# folder of the load.py
os.chdir(r'c:\users\zhuang\.conda\envs\myenv\lib\site-packages\pyspedas\psp')
from config import CONFIG
no_update=False
files = download(remote_file=remote_names, remote_path=CONFIG['remote_data_dir'], local_path=CONFIG['local_data_dir'], no_download=no_update)

```

