### PR TITLE
PSP FIELDS Filtering Added (#191)

### DIFF
--- a/pyspedas/psp/__init__.py
+++ b/pyspedas/psp/__init__.py
@@ -1,8 +1,10 @@
 
 from .load import load
+from .filter import filter_fields
 
-from pytplot import options
+from pytplot import options, data_quants
 
+# Loading
 def fields(trange=['2018-11-5', '2018-11-6'], 
         datatype='mag_rtn', 
         level='l2',
@@ -13,7 +15,10 @@ def fields(trange=['2018-11-5', '2018-11-6'],
         downloadonly=False,
         notplot=False,
         no_update=False,
-        time_clip=False):
+        time_clip=False,
+        username=None,
+        password=None
+        ):
     """
     This function loads Parker Solar Probe FIELDS data
     
@@ -25,7 +30,26 @@ def fields(trange=['2018-11-5', '2018-11-6'],
             ['YYYY-MM-DD/hh:mm:ss','YYYY-MM-DD/hh:mm:ss']
 
         datatype: str
-            Data type; Valid options:
+            Data type; Valid options include:
+                'mag_RTN'
+                'mag_RTN_1min'
+                'mag_rtn_4_per_cycle' (SPDF only)
+                'mag_RTN_4_Sa_per_Cyc' 
+                'mag_SC'
+                'mag_SC_1min'
+                'mag_sc_4_per_cycle' (SPDF only)
+                'mag_SC_4_Sa_per_Cyc' 
+                'mag_VSO' (limited dates)
+                'rfs_burst' (limited dates)
+                'rfs_hfr', 
+                'rfs_lfr'
+                'f2_100bps'
+                'dfb_dc_spec'
+                'dfb_ac_spec'
+                'dfb_dc_xspec'
+                'dfb_ac_xspec'
+                'merged_scam_wf'
+                'sqtn_rfs_V1V2'
 
         suffix: str
             The tplot variable names will be given this suffix.  By default, 
@@ -33,8 +57,8 @@ def fields(trange=['2018-11-5', '2018-11-6'],
 
         get_support_data: bool
             Data with an attribute "VAR_TYPE" with a value of "support_data"
-            will be loaded into tplot.  By default, only loads in data with a 
-            "VAR_TYPE" attribute of "data".
+            will be loaded into tplot.  By default, FIELDS support data is loaded
+            to enable filtering on quality flags.
 
         varformat: str
             The file variable formats to load into tplot.  Wildcard character
@@ -57,18 +81,40 @@ def fields(trange=['2018-11-5', '2018-11-6'],
         time_clip: bool
             Time clip the variables to exactly the range specified in the trange keyword
 
+        username: str
+            Username to use for authentication.
+
+            If passed, attempt to download data from the FIELDS Instrument Team server
+            instead of the fully public server at SPDF.
+            Provides access to unpublished, V02 files.
+
+            Implemented for dataypes:
+                'mag_RTN_1min'
+                'mag_RTN_4_Sa_per_Cyc'
+                'mag_SC'
+                'mag_SC_1min'
+                'mag_SC_4_Sa_per_Cyc'
+                'sqtn_rfs_V1V2'
+
+        password: str
+            Password to use for authentication
+
     Returns
     ----------
         List of tplot variables created.
 
     """
 
-    # SCaM data is Level 3
-    if datatype == 'merged_scam_wf':
+    if suffix:
+        suffix = '_' + suffix
+
+    # SCaM and QTN data are Level 3
+    if datatype.lower() in ['merged_scam_wf', 'sqtn_rfs_v1v2']:
         level = 'l3'
+        print("Using LEVEL=L3")
 
     spec_types = None
-    if datatype == 'dfb_dc_spec' or datatype == 'dfb_ac_spec' or datatype == 'dfb_dc_xspec' or datatype == 'dfb_ac_xspec':
+    if datatype in ['dfb_dc_spec', 'dfb_ac_spec', 'dfb_dc_xspec', 'dfb_ac_xspec']:
         if level == 'l1':
             spec_types = ['1', '2', '3', '4']
         else:
@@ -84,15 +130,45 @@ def fields(trange=['2018-11-5', '2018-11-6'],
                     'SCMulfhg_SCMvlfhg','SCMulfhg_SCMwlfhg','SCMvlfhg_SCMwlfhg',
                     'dV12hg_dV34hg']
 
-    loaded_vars = load(instrument='fields', trange=trange, datatype=datatype, spec_types=spec_types, level=level, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
+    loaded_vars = load(
+        instrument='fields', trange=trange, datatype=datatype, spec_types=spec_types, level=level, 
+        suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, 
+        downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update,
+        username=username, password=password
+    )
     
     if loaded_vars is None or notplot or downloadonly:
         return loaded_vars
 
-    if 'psp_fld_l2_mag_RTN'+suffix in loaded_vars:
-        options('psp_fld_l2_mag_RTN'+suffix, 'legend_names', ['Br (RTN)', 'Bt (RTN)', 'Bn (RTN)'])
+    # If variables are loaded that quality flag filtering supports --
+    # Make sure the quality flag variable is also loaded and linked. 
+    mag_rtnvars = [x for x in loaded_vars if 'fld_l2_mag_RTN' in x ]
+    mag_scvars = [x for x in loaded_vars if 'fld_l2_mag_SC' in x ]
+    rfs_vars = [x for x in loaded_vars if 'rfs_lfr' in x or 'rfs_hfr' in x]
+    if (len(mag_rtnvars + mag_scvars + rfs_vars) > 0) \
+        & ('psp_fld_l2_quality_flags'+suffix not in loaded_vars):
+        loaded_extra = load(
+            instrument='fields', trange=trange, datatype=datatype, spec_types=spec_types, level=level, 
+            suffix=suffix, get_support_data=True, varformat=varformat, varnames=['psp_fld_l2_quality_flags'], 
+            downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update,
+            username=username, password=password
+        )
+        qf_root = 'psp_fld_l2_quality_flags'+suffix if 'psp_fld_l2_quality_flags'+suffix in loaded_extra else None
+        loaded_vars += loaded_extra
+
+    for var in mag_rtnvars:
+        options(var, 'legend_names', ['Br (RTN)', 'Bt (RTN)', 'Bn (RTN)'])
+        data_quants[var] = data_quants[var].assign_attrs({'qf_root':qf_root})
+
+    for var in mag_scvars:
+        options(var, 'legend_names', ['Bx', 'By', 'Bz'])
+        data_quants[var] = data_quants[var].assign_attrs({'qf_root':qf_root})
+
+    for var in rfs_vars:
+        data_quants[var] = data_quants[var].assign_attrs({'qf_root':qf_root})
 
     return loaded_vars
+
 
 def spc(trange=['2018-11-5', '2018-11-6'], 
         datatype='l3i', 
@@ -104,7 +180,10 @@ def spc(trange=['2018-11-5', '2018-11-6'],
         downloadonly=False,
         notplot=False,
         no_update=False,
-        time_clip=False):
+        time_clip=False,
+        username=None,
+        password=None
+    ):
     """
     This function loads Parker Solar Probe Solar Probe Cup data
     
@@ -116,7 +195,9 @@ def spc(trange=['2018-11-5', '2018-11-6'],
             ['YYYY-MM-DD/hh:mm:ss','YYYY-MM-DD/hh:mm:ss']
 
         datatype: str
-            Data type; Valid options:
+            Data type; Valid options include:
+                'l3i' (level='l3')
+                'l2i' (level='l2')
 
         suffix: str
             The tplot variable names will be given this suffix.  By default, 
@@ -148,12 +229,32 @@ def spc(trange=['2018-11-5', '2018-11-6'],
         time_clip: bool
             Time clip the variables to exactly the range specified in the trange keyword
 
+        username: str
+            Username to use for authentication.
+            
+            If passed, attempt to download data from the SWEAP Instrument Team server
+            instead of the fully public server at SPDF.
+            Provides access to unpublished files.
+
+        password: str
+            Password to use for authentication
+
     Returns
     ----------
         List of tplot variables created.
 
     """
-    return load(instrument='spc', trange=trange, datatype=datatype, level=level, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
+
+    if datatype == 'l3i':
+        level = 'l3'
+        print("Using LEVEL=L3")
+    elif datatype == 'l2i':
+        level = 'l2'
+        print("Using LEVEL=L2")
+
+    return load(instrument='spc', trange=trange, datatype=datatype, level=level, suffix=suffix, 
+        get_support_data=get_support_data, varformat=varformat, varnames=varnames, downloadonly=downloadonly, 
+        notplot=notplot, time_clip=time_clip, no_update=no_update, username=username, password=password)
 
 def spe(trange=['2018-11-5', '2018-11-6'], 
         datatype='spa_sf1_32e', 
@@ -165,7 +266,8 @@ def spe(trange=['2018-11-5', '2018-11-6'],
         downloadonly=False,
         notplot=False,
         no_update=False,
-        time_clip=False):
+        time_clip=False
+    ):
     """
     This function loads Parker Solar Probe SWEAP/SPAN-e data
     
@@ -177,7 +279,14 @@ def spe(trange=['2018-11-5', '2018-11-6'],
             ['YYYY-MM-DD/hh:mm:ss','YYYY-MM-DD/hh:mm:ss']
 
         datatype: str
-            Data type; Valid options:
+            Data type; Valid options include:
+                spa_sf0_pad  (L3)
+                spb_sf0_pad  (L3)
+                spe_sf0_pad  (L3)
+                spa_sf1_32e  (L2)
+                spb_sf1_32e  (L2)
+                spa_sf0_16ax8dx32e  (L2)
+                spb_sf0_16ax8dx32e  (L2)
 
         suffix: str
             The tplot variable names will be given this suffix.  By default, 
@@ -214,10 +323,12 @@ def spe(trange=['2018-11-5', '2018-11-6'],
         List of tplot variables created.
 
     """
-    return load(instrument='spe', trange=trange, datatype=datatype, level=level, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
+    return load(instrument='spe', trange=trange, datatype=datatype, level=level, 
+        suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, 
+        downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
 
 def spi(trange=['2018-11-5', '2018-11-6'], 
-        datatype='spi_sf0a_mom_inst', 
+        datatype='sf00_l3_mom', 
         level='l3',
         suffix='',  
         get_support_data=False, 
@@ -226,7 +337,10 @@ def spi(trange=['2018-11-5', '2018-11-6'],
         downloadonly=False,
         notplot=False,
         no_update=False,
-        time_clip=False):
+        time_clip=False,
+        username=None,
+        password=None
+    ):
     """
     This function loads Parker Solar Probe SWEAP/SPAN-i data
     
@@ -238,7 +352,11 @@ def spi(trange=['2018-11-5', '2018-11-6'],
             ['YYYY-MM-DD/hh:mm:ss','YYYY-MM-DD/hh:mm:ss']
 
         datatype: str
-            Data type; Valid options:
+            Data type; Valid options Include:
+                'sf00_l3_mom': Moments of the Proton distribution function (RTN)
+                'sf0a_l3_mom': Moments of the Alpha distribution function (RTN)
+                'sf00_l3_mom_inst': Moments of the Proton distribution function (Instrument Frame)
+                'sf0a_l3_mom_inst': Moments of the Alpha distribution function (Instrument Frame)
 
         suffix: str
             The tplot variable names will be given this suffix.  By default, 
@@ -270,12 +388,31 @@ def spi(trange=['2018-11-5', '2018-11-6'],
         time_clip: bool
             Time clip the variables to exactly the range specified in the trange keyword
 
+        username: str
+            Username to use for authentication.
+            
+            If passed, attempt to download data from the SWEAP Instrument Team server
+            instead of the fully public server at SPDF.
+            Provides access to unpublished files.
+
+        password: str
+            Password to use for authentication
+
     Returns
     ----------
         List of tplot variables created.
 
     """
-    return load(instrument='spi', trange=trange, datatype=datatype, level=level, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
+    if datatype in ['sf00_l3_mom','sf0a_l3_mom','sf00_l3_mom_inst','sf0a_l3_mom_inst']:
+        datatype = 'spi_' + datatype
+        level = 'l3'
+        print("Using LEVEL=L3")
+
+    return load(instrument='spi', trange=trange, datatype=datatype, level=level, 
+        suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, 
+        downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update, 
+        username=username, password=password
+        )
 
 def epihi(trange=['2018-11-5', '2018-11-6'], 
         datatype='let1_rates1h', 
@@ -336,7 +473,9 @@ def epihi(trange=['2018-11-5', '2018-11-6'],
         List of tplot variables created.
 
     """
-    return load(instrument='epihi', trange=trange, datatype=datatype, level=level, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
+    return load(instrument='epihi', trange=trange, datatype=datatype, level=level, 
+        suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, 
+        downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
 
 def epilo(trange=['2018-11-5', '2018-11-6'], 
         datatype='pe', 
@@ -397,7 +536,9 @@ def epilo(trange=['2018-11-5', '2018-11-6'],
         List of tplot variables created.
 
     """
-    return load(instrument='epilo', trange=trange, datatype=datatype, level=level, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
+    return load(instrument='epilo', trange=trange, datatype=datatype, level=level, 
+        suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, 
+        downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
 
 def epi(trange=['2018-11-5', '2018-11-6'], 
         datatype='summary', 
@@ -458,4 +599,7 @@ def epi(trange=['2018-11-5', '2018-11-6'],
         List of tplot variables created.
 
     """
-    return load(instrument='epi', trange=trange, datatype=datatype, level=level, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
+    return load(instrument='epi', trange=trange, datatype=datatype, level=level, 
+        suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, 
+        downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
+

--- a/pyspedas/psp/config.py
+++ b/pyspedas/psp/config.py
@@ -1,7 +1,11 @@
 import os
 
-CONFIG = {'local_data_dir': 'psp_data/',
-          'remote_data_dir': 'https://spdf.gsfc.nasa.gov/pub/data/psp/'}
+CONFIG = {
+    'local_data_dir': 'psp_data/',
+    'remote_data_dir': 'https://spdf.gsfc.nasa.gov/pub/data/psp/',
+    'sweap_remote_data_dir': 'http://sweap.cfa.harvard.edu/data/sci/',
+    'fields_remote_data_dir': 'https://sprg.ssl.berkeley.edu/data/spp/data/sci/'
+}
 
 # override local data directory with environment variables
 if os.environ.get('SPEDAS_DATA_DIR'):

--- a/pyspedas/psp/filter.py
+++ b/pyspedas/psp/filter.py
@@ -1,0 +1,307 @@
+# Filtering Utilities
+import enum
+import numpy as np
+from copy import deepcopy
+from collections.abc import Iterable
+from pytplot import tplot_names, data_quants, get_timespan, get_data, store_data
+
+def filter_fields(tvars, dqflag = 0, names_out = True):
+    """
+    This function removes flagged values from PSP FIELDS magnetometer tplot 
+    variables based on selected quality flags.  
+    
+    For each TVAR passed in a new tplot variable is created with the filtered 
+    data.  The new name is of the form:  <tvarname>_XXXXXX 
+    where each 'XXX' is a 0 padded flag indicator sorted from lowest to highest.
+ 
+    So, psp.filter_FIELDS('mag_RTN_1min_x',[4,16]) 
+        - results in tvar named "mag_RTN_1min_x_004016"
+        - tvar holds data where *NEITHER* flag 4 NOR flag 16 is set.
+
+    Or, psp.filter_FIELDS('mag_RTN_1min',0) 
+        - results in tvar named "mag_RTN_1min_000"
+        - tvar holds data with no set flags
+    
+    Valid only for variables of type:
+        '...psp_fld_l2_mag_...' (full res, 1 minute, or 4 Sa per cycle)
+        '...psp_fld_l2_rfs_...' (lfr and hfr) 
+
+    Parameters
+    ----------
+        tvars: str or list of strings
+            Tplot variable names, previously loaded
+
+        dqflag: int or list of ints
+            Elements indicate which of the data quality flags
+            to filter on.             
+            From the set {-1,0,1,2,4,8,16,32,64,128,256,512} 
+
+            For flags >= 1: filters OUT wherever ANY of the selected flags are set.
+
+            Note: if using 0 or -1, no other flags should be selected
+            -1: Keep cases with no set flags or only the 128 flag set 
+            0: No set flags. (default)
+            1: FIELDS antenna bias sweep
+            2: PSP thruster firing
+            4: SCM Calibration
+            8: PSP rotations for MAG calibration (MAG rolls)
+            16: FIELDS MAG calibration sequence
+            32: SWEAP SPC in electron mode
+            64: PSP Solar limb sensor (SLS) test
+            128: PSP spacecraft is off umbra pointing  
+            256: High frequency noise affecting RFS and TDS receivers. 
+            512: Antennas driven towards the FIELDS power supply rails.   
+
+        names_out: bool
+            If set, return a list of the tplot variable names created 
+            from this filter. Order corresponds to the input array of tvar
+            names, so that tvar[i] filtered is in names_out[i]
+
+    Returns
+    ----------
+        None or List of tplot variables created if name_out=True (default)
+    """
+
+    new_names = [] if names_out else None
+
+    # Check arguments
+    if isinstance(tvars, str):
+        tvars = [tvars]
+
+    if not isinstance(dqflag, Iterable):
+        dqflag = [dqflag]
+
+    for flg in dqflag:
+        assert flg in {-1,0,1,2,4,8,16,32,64,128,256,512}, "Bad FIELDS Quality Flag: {}".format(flg)
+
+    if len(dqflag) > 1:
+        assert 0 not in dqflag, 'DQFLAG of 0 must be set by itself'
+        assert -1 not in dqflag, 'DQFLAG of -1 must be set by itself'
+
+    dqflag.sort()
+
+    # Reduce list to supported variables that are already loaded
+    tvars = [x for x in tvars if x in tplot_names(quiet=True)]
+
+    tvars = [x for x in tvars if 'fld_l2_mag_RTN' in x 
+                              or 'fld_l2_mag_SC' in x 
+                              or 'rfs_lfr' in x
+                              or 'rfs_hfr' in x]
+    if len(tvars) == 0:
+        print("No valid variables for filtering")
+        return new_names       
+
+    # Create time specific quality flags as needed
+    qf_target = []
+    err_flg = []
+    keep = []
+    for tvar in tvars:
+
+        qf_root = data_quants[tvar].qf_root
+        if qf_root:
+            keep.append(tvar)
+            if ('rfs_hfr' in tvar) or ('rfs_lfr' in tvar):
+                # Lots of possible epoch tags for the rfs data
+                tag = '_' + data_quants[tvar].CDF['VATT']['DEPEND_0']
+            elif '_1min' in tvar:
+                tag = '_1min'
+            elif '_4_Sa_per_Cyc' in tvar:
+                tag = '_4_per_cycle'
+            else:
+                tag = '_hires'
+
+            make_qf_var = False
+            if qf_root + tag in data_quants.keys():
+                # Variable exists.  Is it in the right time range?
+                varTR = get_timespan(tvar)
+                qfTR = get_timespan(tvar)
+                if (qfTR[0] != varTR[0]) or (qfTR[1] != varTR[1]):
+                    make_qf_var = True                
+            else:
+                make_qf_var = True
+
+            if make_qf_var:
+                err = _ff_match_qf_epochs(tvar, qf_root, tag)
+                err_flg.append(err)
+            else:
+                err_flg.append(0)
+
+            qf_target.append(qf_root + tag)
+        else:
+            print("Source quality flags missing. No filtered variabled created for: {}".format(tvar))
+    
+    # Remove cases where match epochs couldn't work
+    valid_tn = [keep[i] for i in range(len(keep)) if err_flg[i] == 0]
+    qf_target = [qf_target[i] for i in range(len(keep)) if err_flg[i] == 0]
+    bad_tn = [keep[i] for i in range(len(keep)) if err_flg[i] == 1]
+    if len(bad_tn) > 0:
+        print("Error creating some matching time quality flags.")
+        for tn in bad_tn:
+            print("No filtered variabled created for: {}".format(tn))
+
+    # Create the filtered variables
+    if len(valid_tn) == 0:
+        print("No valid variables for filtering\n")
+
+    else:
+        qfmap = dict()
+        
+        # Handle simpler cases, just the 0 or -1 flag
+        if len(dqflag) == 1 and dqflag[0] in [0, -1]:
+            # Get the quality flag arrays
+            for qfname in qf_target:
+                if qfname not in qfmap:
+                    d = get_data(qfname)
+                    qfmap[qfname] = d.y
+
+            for i, tn in enumerate(valid_tn):
+                if dqflag[0] == 0:
+                    suffix = '_000'
+                    mask = qfmap[qf_target[i]] != 0
+                else:
+                    suffix = '_0-1'
+                    mask = (qfmap[qf_target[i]] != 0) & (qfmap[qf_target[i]] != 128)
+                new_attrs = deepcopy(get_data(tn, metadata=True))
+                if 'CDF' in new_attrs:
+                    _ = new_attrs.pop('CDF')
+                new_attrs['qf_root'] = None
+                new_attrs['plot_options']['yaxis_opt']['axis_label'] += '\n(flt: {})'.format(suffix)  # TODO: how to increase left margin programmatically so this can be a new line?! (default matplotlib is .1 normal)
+                
+                data = deepcopy(get_data(tn))
+                if issubclass(data.y.dtype.type, np.integer):
+                    new_data = {'x':data.times, 'y':data.y.astype(float)}
+                else:
+                    new_data = {'x':data.times, 'y':data.y}
+
+                try:
+                    new_data['v'] = data.v
+                except:
+                    pass
+   
+                new_data['y'][mask] = np.nan
+
+                store_data(tn+suffix, new_data, attr_dict=new_attrs)
+                if names_out:
+                    new_names.append(tn+suffix)
+
+        # Handle multiple flags
+        else:
+            # Get quality flag arrays and flagged bits
+            for qfname in qf_target:
+                if qfname not in qfmap:
+                    d = get_data(qfname)
+                    qfmap[qfname] = dict()
+                    qfmap[qfname]['dqf'] = d.y
+                    qfmap[qfname]['dqfbits'] = _ff_unpackbits(d.y)
+
+            suffix = '_'
+            mybits = _ff_unpackbits(np.uint32(0))
+            for flg in dqflag:
+                suffix += '{:03}'.format(flg)
+                mybits += _ff_unpackbits(np.uint32(flg))
+
+            for i, tn in enumerate(valid_tn):
+                new_attrs = deepcopy(get_data(tn, metadata=True))
+                if 'CDF' in new_attrs:
+                    _ = new_attrs.pop('CDF')
+                new_attrs['qf_root'] = None
+                new_attrs['plot_options']['yaxis_opt']['axis_label'] += '\n(flt: {})'.format(suffix) # TODO: how to increase left margin programmatically so this can be a new line and visisble by default?! (default matplotlib is .1 normal)
+                
+                data = deepcopy(get_data(tn))
+                if issubclass(data.y.dtype.type, np.integer):
+                    new_data = {'x':data.times, 'y':data.y.astype(float)}
+                else:
+                    new_data = {'x':data.times, 'y':data.y}
+
+                try:
+                    new_data['v'] = data.v
+                except:
+                    pass
+
+                rem_mask = np.full(len(new_data['y']), False)
+                for j in range(len(mybits)):
+                    if mybits[j] == 1:
+                        mask = qfmap[qf_target[i]]['dqfbits'][:, j] == 1
+                        rem_mask[mask] = True
+                new_data['y'][rem_mask] = np.nan
+                    
+                store_data(tn+suffix, new_data, attr_dict=new_attrs)
+                if names_out:
+                    new_names.append(tn+suffix)
+    return new_names
+
+
+def _ff_unpackbits(x):
+    """
+    Like np.unpackbits but works for all uint dtypes (not just uint8)
+    Adapated from https://stackoverflow.com/a/51509307
+    """
+    if np.issubdtype(x.dtype, np.floating):
+        raise ValueError("numpy data type needs to be int-like")
+    num_bits = 8 * x.dtype.itemsize
+
+    xshape = list(x.shape)
+    x = x.reshape([-1, 1])
+    mask = 2**np.arange(num_bits, dtype=x.dtype).reshape([1, num_bits])
+    return (x & mask).astype(bool).astype(int).reshape(xshape + [num_bits])
+
+
+def _ff_match_qf_epochs(target, source, tag):
+    """
+    Helper to psp.fields_filter routine.  Extends the quality_flag variable to
+    match the time resolution target.  Results valid only if the source epochs
+    and target epochs cover the same time period.
+    
+    Points in the target epoch falling before the source epoch start time will 
+    contain the quality flag of the earliest entry in the quality flag variable.
+    
+    Points in the target epoch falling after the source epoch end time will 
+    contain the quality flag of the last entry in the quality flag variable.
+
+    Parameters
+    ----------
+        target: str
+            Tplot variable name with the target epoch times
+
+        source: str
+            Tplot variable name with the source epoch times (ie: root quality flag variable)
+
+        tag: str
+            Tplot variable name suffix for new quality flag variable
+    
+    Returns
+    ----------
+        error: int
+            Error status
+            0 for nominal execution
+            1 if the source and target epoch ranges are completely disjoint
+                or do not overlap by at least 90% of the target time range.
+                No new tplot variables are created in this instance.    
+    """
+    
+    qfd = get_data(source)
+    src = qfd.times
+    tar = get_data(target).times.copy()
+
+    # Check for valid ranges
+    if (tar[-1] < src[0]) or (tar[0] > src[-1]):
+        print("Epoch ranges are disjoint.")
+        return 1
+    else:
+        tar_dur = tar[-1] - tar[0]
+        src_overlap = src[(src >= tar[0]) & (src <= tar[-1])]
+        overlap_dur = src_overlap[-1] - src_overlap[0]
+        if overlap_dur/tar_dur < 0.9:
+            print("Bad epoch ranges.")
+            return 1
+
+    newY = np.full_like(tar, qfd.y[0], dtype=qfd.y.dtype)
+    for i in range(len(src) - 1):
+        mask = (tar >= src[i]) & (tar < src[i+1])
+        newY[mask] = qfd.y[i].copy()
+    mask = tar >= src[-1]
+    newY[mask] = qfd.y[-1].copy()
+
+    newData = {'x':tar, 'y':newY}
+    store_data(source+tag, newData)
+    return 0

--- a/pyspedas/psp/load.py
+++ b/pyspedas/psp/load.py
@@ -7,7 +7,7 @@ from .config import CONFIG
 
 def load(trange=['2018-11-5', '2018-11-6'], 
          instrument='fields', 
-         datatype='mag_rtn', 
+         datatype='mag_RTN', 
          spec_types=None, # for DFB AC spectral data
          level='l2',
          suffix='', 
@@ -17,7 +17,10 @@ def load(trange=['2018-11-5', '2018-11-6'],
          downloadonly=False,
          notplot=False,
          no_update=False,
-         time_clip=False):
+         time_clip=False,
+         username=None,
+         password=None
+         ):
     """
     This function loads Parker Solar Probe data into tplot variables; this function is not 
     meant to be called directly; instead, see the wrappers: 
@@ -31,22 +34,36 @@ def load(trange=['2018-11-5', '2018-11-6'],
     
     """
 
-    # remote path formats are going to be all lowercase
-    datatype = datatype.lower()
+    # remote path formats generally are going to be all lowercase except for
+    # on the Berkeley FIELDS server
+    if (username is not None) and (datatype in ['mag_RTN_1min',
+                                            'mag_RTN_4_Sa_per_Cyc'
+                                            'mag_SC'
+                                            'mag_SC_1min'
+                                            'mag_SC_4_Sa_per_Cyc']):
+        pass
+    else:
+        datatype = datatype.lower()
+
+    prefix = 'psp_'  #To cover the case if one *does* call this routine directly.
 
     file_resolution = 24*3600.
-
     if instrument == 'fields':
+        prefix = '' #CDF Variables are already prefixed with psp_fld_
+
         # 4_per_cycle and 1min are daily, not 6h like the full resolution 'mag_(rtn|sc)'
-        if datatype == 'mag_rtn_1min' or datatype == 'mag_sc_1min':
+        if datatype in ['mag_rtn', 'mag_sc']:
+            pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d%H_v??.cdf'
+            file_resolution = 6*3600.
+        elif datatype in ['mag_rtn_1min', 'mag_sc_1min', 'rfs_hfr', 'rfs_lfr', 'rfs_burst', 'f2_100bps']:
             pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v??.cdf'
-        elif datatype == 'mag_rtn_4_per_cycle' or datatype == 'mag_rtn_4_sa_per_cyc':
+        elif datatype in ['mag_rtn_4_per_cycle', 'mag_rtn_4_sa_per_cyc']:
             pathformat = instrument + '/' + level + '/mag_rtn_4_per_cycle/%Y/psp_fld_' + level + '_mag_rtn_4_sa_per_cyc_%Y%m%d_v??.cdf'
-        elif datatype == 'mag_sc_4_per_cycle' or datatype == 'mag_sc_4_sa_per_cyc':
+        elif datatype in ['mag_sc_4_per_cycle', 'mag_sc_4_sa_per_cyc']:
             pathformat = instrument + '/' + level + '/mag_sc_4_per_cycle/%Y/psp_fld_' + level + '_mag_sc_4_sa_per_cyc_%Y%m%d_v??.cdf'
-        elif datatype == 'rfs_hfr' or datatype == 'rfs_lfr' or datatype == 'rfs_burst' or datatype == 'f2_100bps':
-            pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v??.cdf'
-        elif datatype == 'dfb_dc_spec' or datatype == 'dfb_ac_spec' or datatype == 'dfb_dc_xspec' or datatype == 'dfb_ac_xspec':
+        elif datatype == 'sqtn_rfs_v1v2':
+            pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v?.?.cdf'        
+        elif datatype in ['dfb_dc_spec', 'dfb_ac_spec', 'dfb_dc_xspec', 'dfb_ac_xspec']:
             out_vars = []
             for item in spec_types:
                 loaded_data = load(trange=trange, instrument=instrument, datatype=datatype + '_' + item, level=level, 
@@ -64,20 +81,51 @@ def load(trange=['2018-11-5', '2018-11-6'],
                 stype_tmp = datatype[12:]
             pathformat = instrument + '/' + level + '/' + dtype_tmp + '/' + stype_tmp + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v??.cdf'
 
+
+
+        # unpublished data (only download v02 mag data which would be published)
+        elif username != None:
+            if datatype in ['mag_RTN', 'mag_SC']:
+                pathformat = instrument + '/' + level + '/' + datatype + '/%Y/%m/psp_fld_' + level + '_' + datatype + '_%Y%m%d%H_v02.cdf'
+                file_resolution = 6*3600.
+
+            elif datatype in ['mag_RTN_1min', 'mag_RTN_4_Sa_per_Cyc', 'mag_SC_1min', 'mag_SC_4_Sa_per_Cyc']:
+                pathformat = instrument + '/' + level + '/' + datatype + '/%Y/%m/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v02.cdf'
+
+            elif datatype ==  'sqtn_rfs_V1V2':
+                pathformat = instrument + '/' + level + '/' + datatype + '/%Y/%m/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v?.?.cdf'
+
         else:
+            # Generic SPDF path.  
             pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d%H_v??.cdf'
             file_resolution = 6*3600.
+
     elif instrument == 'spc':
-        pathformat = 'sweap/spc/' + level + '/' + datatype + '/%Y/psp_swp_spc_' + datatype + '_%Y%m%d_v??.cdf'
+        prefix = 'psp_spc_'
+        if username is None:
+            pathformat = 'sweap/spc/' + level + '/' + datatype + '/%Y/psp_swp_spc_' + datatype + '_%Y%m%d_v??.cdf'
+        else:
+            # unpublished data
+            pathformat = 'sweap/spc/' + level + '/%Y/%m/psp_swp_spc_' + datatype + '_%Y%m%d_v0?.cdf'
     elif instrument == 'spe':
+        prefix = 'psp_spe_'
         pathformat = 'sweap/spe/' + level + '/' + datatype + '/%Y/psp_swp_sp?_*_%Y%m%d_v??.cdf'
     elif instrument == 'spi':
-        pathformat = 'sweap/spi/' + level + '/' + datatype + '/%Y/psp_swp_spi_*_%Y%m%d_v??.cdf'
+        if username is None:
+            prefix = 'psp_spi_'
+            pathformat = 'sweap/spi/' + level + '/' + datatype + '/%Y/psp_swp_spi_*_%Y%m%d_v??.cdf'
+        else:
+            # unpublished data
+            prefix = 'psp_spi_'
+            pathformat = 'sweap/spi/' + level + '/' + datatype + '/%Y/%m/psp_swp_' + datatype + '*_%Y%m%d_v0?.cdf'
     elif instrument == 'epihi':
+        prefix = 'psp_epihi_'
         pathformat = 'isois/epihi/' + level + '/' + datatype + '/%Y/psp_isois-epihi_' + level + '*_%Y%m%d_v??.cdf'
     elif instrument == 'epilo':
+        prefix = 'psp_epilo_'
         pathformat = 'isois/epilo/' + level + '/' + datatype + '/%Y/psp_isois-epilo_' + level + '*_%Y%m%d_v??.cdf'
     elif instrument == 'epi':
+        prefix = 'psp_isois_'
         pathformat = 'isois/merged/' + level + '/' + datatype + '/%Y/psp_isois_' + level + '-' + datatype + '_%Y%m%d_v??.cdf'
 
     # find the full remote path names using the trange
@@ -85,7 +133,34 @@ def load(trange=['2018-11-5', '2018-11-6'],
 
     out_files = []
 
-    files = download(remote_file=remote_names, remote_path=CONFIG['remote_data_dir'], local_path=CONFIG['local_data_dir'], no_download=no_update)
+    if username is None:
+        files = download(remote_file=remote_names, remote_path=CONFIG['remote_data_dir'], 
+                        local_path=CONFIG['local_data_dir'], no_download=no_update)
+    else:
+        if instrument == 'fields':
+            try:
+                print("Downloading unpublished Data....")
+                files = download(
+                    remote_file=remote_names, remote_path=CONFIG['fields_remote_data_dir'], 
+                    local_path=CONFIG['local_data_dir'], no_download=no_update,
+                    username=username, password=password, basic_auth=True
+                )
+            except:
+                files = download(remote_file=remote_names, remote_path=CONFIG['remote_data_dir'], 
+                                local_path=CONFIG['local_data_dir'], no_download=no_update)
+        elif instrument in ['spc','spi']:
+            try:
+                print("Downloading unpublished Data....")
+                files = download(
+                    remote_file=remote_names, remote_path=CONFIG['sweap_remote_data_dir'], 
+                    local_path=CONFIG['local_data_dir'], no_download=no_update,
+                    username=username, password=password, basic_auth=True
+                )
+            except:
+                files = download(remote_file=remote_names, remote_path=CONFIG['remote_data_dir'], 
+                                local_path=CONFIG['local_data_dir'], no_download=no_update)
+        
+
     if files is not None:
         for file in files:
             out_files.append(file)
@@ -95,7 +170,8 @@ def load(trange=['2018-11-5', '2018-11-6'],
     if downloadonly:
         return out_files
 
-    tvars = cdf_to_tplot(out_files, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, notplot=notplot)
+    tvars = cdf_to_tplot(out_files, suffix=suffix, prefix=prefix, get_support_data=get_support_data, 
+                        varformat=varformat, varnames=varnames, notplot=notplot)
 
     if notplot:
         return tvars


### PR DESCRIPTION
* Adds the psp.filter_fields() function to filter PSP FIELDS instrument magnetic field and rfs datatypes by various quality flag combinations.
* Additional minor revisions to the PSP load routines have been made to add more information to the docstrings and support required options for filtering.