### PR TITLE
Allow different file versions for PSP/FIELDS non-public data

### DIFF
--- a/pyspedas/psp/load.py
+++ b/pyspedas/psp/load.py
@@ -37,9 +37,10 @@ def load(trange=['2018-11-5', '2018-11-6'],
     # remote path formats generally are going to be all lowercase except for
     # on the Berkeley FIELDS server
     if (username is not None) and (datatype in ['mag_RTN_1min',
-                                            'mag_RTN_4_Sa_per_Cyc'
-                                            'mag_SC'
-                                            'mag_SC_1min'
+                                            'mag_RTN_4_Sa_per_Cyc',
+                                            'mag_RTN',
+                                            'mag_SC',
+                                            'mag_SC_1min',
                                             'mag_SC_4_Sa_per_Cyc']):
         pass
     else:

--- a/pyspedas/psp/load.py
+++ b/pyspedas/psp/load.py
@@ -83,14 +83,14 @@ def load(trange=['2018-11-5', '2018-11-6'],
 
 
 
-        # unpublished data (only download v02 mag data which would be published)
+        # unpublished data
         elif username != None:
             if datatype in ['mag_RTN', 'mag_SC']:
-                pathformat = instrument + '/' + level + '/' + datatype + '/%Y/%m/psp_fld_' + level + '_' + datatype + '_%Y%m%d%H_v02.cdf'
+                pathformat = instrument + '/' + level + '/' + datatype + '/%Y/%m/psp_fld_' + level + '_' + datatype + '_%Y%m%d%H_v??.cdf'
                 file_resolution = 6*3600.
 
             elif datatype in ['mag_RTN_1min', 'mag_RTN_4_Sa_per_Cyc', 'mag_SC_1min', 'mag_SC_4_Sa_per_Cyc']:
-                pathformat = instrument + '/' + level + '/' + datatype + '/%Y/%m/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v02.cdf'
+                pathformat = instrument + '/' + level + '/' + datatype + '/%Y/%m/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v??.cdf'
 
             elif datatype ==  'sqtn_rfs_V1V2':
                 pathformat = instrument + '/' + level + '/' + datatype + '/%Y/%m/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v?.?.cdf'


### PR DESCRIPTION
Currently, when trying to request FIELDS MAG non-public data, the previous version is hardcoded to only look for v02 which is because v02 is typically what eventually becomes public. However, pyspedas is really helpful for PSP team members in assessing the early data and when the data is first available it is posted as v00, then v01 etc.. as more accurate telemetry becomes available. Therefore its useful to have the filename versions be flexible as with non-public data. 

This PR simply changes v02 to v?? at the relevant places in `pyspedas.psp.load` to allow this. 