### PR TITLE
Add STEREO WAVES download routines

### DIFF
--- a/pyspedas/stereo/README.md
+++ b/pyspedas/stereo/README.md
@@ -65,3 +65,10 @@ plastic_vars = pyspedas.stereo.plastic(trange=['2013-11-5', '2013-11-6'])
 
 tplot(['proton_number_density', 'proton_bulk_speed', 'proton_temperature', 'proton_thermal_speed'])
 ```
+
+#### STEREO/WAVES (S/WAVES)
+
+```python
+hfr_vars = pyspedas.stereo.waves(trange=['2013-11-5', '2013-11-6'])
+tplot(['PSD_FLUX'])
+```

--- a/pyspedas/stereo/__init__.py
+++ b/pyspedas/stereo/__init__.py
@@ -523,3 +523,68 @@ def plastic(trange=['2013-11-5', '2013-11-6'],
 
     """
     return load(instrument='plastic', trange=trange, probe=probe, level=level, datatype=datatype, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
+
+def waves(trange=['2013-11-5', '2013-11-6'],
+        probe='a',
+        datatype='hfr',
+        level='l3',
+        suffix='',  
+        get_support_data=False, 
+        varformat=None,
+        varnames=[],
+        downloadonly=False,
+        notplot=False,
+        no_update=False,
+        time_clip=False):
+    """
+    This function loads data from the WAVES instrument
+    
+    Parameters
+    ----------
+        trange : list of str
+            time range of interest [starttime, endtime] with the format 
+            'YYYY-MM-DD','YYYY-MM-DD'] or to specify more or less than a day 
+            ['YYYY-MM-DD/hh:mm:ss','YYYY-MM-DD/hh:mm:ss']
+
+        probe: str
+            Spacecraft probe ('a' for ahead, 'b' for behind)
+
+        datatype: str
+            Data type; Valid options: hfr, lfr
+
+        suffix: str
+            The tplot variable names will be given this suffix.  By default, 
+            no suffix is added.
+
+        get_support_data: bool
+            Data with an attribute "VAR_TYPE" with a value of "support_data"
+            will be loaded into tplot.  By default, only loads in data with a 
+            "VAR_TYPE" attribute of "data".
+
+        varformat: str
+            The file variable formats to load into tplot.  Wildcard character
+            "*" is accepted.  By default, all variables are loaded in.
+
+        varnames: list of str
+            List of variable names to load (if not specified,
+            all data variables are loaded)
+
+        downloadonly: bool
+            Set this flag to download the CDF files, but not load them into 
+            tplot variables
+
+        notplot: bool
+            Return the data in hash tables instead of creating tplot variables
+
+        no_update: bool
+            If set, only load data from your local cache
+
+        time_clip: bool
+            Time clip the variables to exactly the range specified in the trange keyword
+
+    Returns
+    ----------
+        List of tplot variables created.
+
+    """
+    return load(instrument='waves', trange=trange, probe=probe, level=level, datatype=datatype, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)

--- a/pyspedas/stereo/load.py
+++ b/pyspedas/stereo/load.py
@@ -52,11 +52,13 @@ def load(trange=['2013-11-5', '2013-11-6'],
                 pathformat = 'plastic/level2/Protons/Derived_from_1D_Maxwellian/'+direction+'/'+datatype+'/%Y/ST'+prb.upper()+'_L2_PLA_1DMax_'+datatype+'_%Y%m%d_V??.cdf'
         elif instrument == 'swea':
             CONFIG['remote_data_dir'] = 'https://spdf.gsfc.nasa.gov/pub/data/stereo/'
-            pathformat = direction + '/' + level + '/impact/swea_' + datatype + '/%Y/sta_' + level + '_swea_' + datatype + '_%Y%m%d_v??.cdf'
+            pathformat = direction + '/' + level + '/impact/swea_' + datatype + f'/%Y/st{prb}_' + level + '_swea_' + datatype + '_%Y%m%d_v??.cdf'
         elif instrument in ['ste', 'sept', 'sit', 'let', 'het']:
             CONFIG['remote_data_dir'] = 'https://spdf.gsfc.nasa.gov/pub/data/stereo/'
-            pathformat = direction + '/' + level + '/impact/' + instrument + '/%Y/sta_' + level + '_' + instrument + '_%Y%m%d_v??.cdf'
-
+            pathformat = direction + '/' + level + '/impact/' + instrument + f'/%Y/st{prb}_' + level + '_' + instrument + '_%Y%m%d_v??.cdf'
+        elif instrument == "waves" :
+            CONFIG['remote_data_dir'] = 'https://spdf.gsfc.nasa.gov/pub/data/stereo/'
+            pathformat = direction + '/' + level + '/waves/' + datatype + f'/%Y/st{prb}_' + level + '_wav_' + datatype + '_%Y%m%d_v??.cdf'
 
         # find the full remote path names using the trange
         remote_names = dailynames(file_format=pathformat, trange=trange)

--- a/pyspedas/stereo/tests/tests.py
+++ b/pyspedas/stereo/tests/tests.py
@@ -47,6 +47,16 @@ class LoadTestCases(unittest.TestCase):
         self.assertTrue(data_exists('proton_bulk_speed'))
         self.assertTrue(data_exists('proton_temperature'))
 
+    def test_load_waves_data_a(self):
+        w_vars = pyspedas.stereo.waves(trange=['2013-11-5', '2013-11-6'], probe='a')
+        self.assertTrue(data_exists('PSD_FLUX'))
+        self.assertTrue(data_exists('PSD_SFU'))
+
+    def test_load_waves_data_b(self):
+        w_vars = pyspedas.stereo.waves(trange=['2013-11-5', '2013-11-6'], probe='b')
+        self.assertTrue(data_exists('PSD_FLUX'))
+        self.assertTrue(data_exists('PSD_SFU'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds the capability of the STEREO module to download STEREO/WAVES HFR and LFR L3 spectrograms, recently arxived on spdf/cdaweb by Vratislav Krupar ( [STEREO A](https://cdaweb.gsfc.nasa.gov/pub/data/stereo/ahead/l3/waves/) and [STEREO B](https://cdaweb.gsfc.nasa.gov/pub/data/stereo/behind/l3/waves/) ) . The default behavior is to download the `hfr` sensor from STEREO A. The level must be set to `l3`.

This also fixes the filename builder in `pyspedas.stereo.load` for swea, ste, sept, sit and let to allow the argument `probe='b'` to function correctly.

Lastly, a test is added to `pyspedas/stereo/tests`, and an entry is entered in `pyspedas/stereo/README.md` to give an example of downloading WAVES data. 