### PR TITLE
Add option to change fill_value in scipy.interpolate.interp1d

### DIFF
--- a/pyspedas/utilities/interpol.py
+++ b/pyspedas/utilities/interpol.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy import interpolate
 
-def interpol(data, data_times, out_times):
+def interpol(data, data_times, out_times, fill_value="extrapolate"):
     '''
     Simple wrapper around scipy's interp1d that allows you to linearly interpolate data from 
     one set of times to another set of times
@@ -14,9 +14,9 @@ def interpol(data, data_times, out_times):
     if len(data.shape) == 2:
         out = np.empty((len(out_times), len(data[0, :])))
         for data_idx in np.arange(len(data[0, :])):
-            interpfunc = interpolate.interp1d(data_times, data[:, data_idx], kind='linear', bounds_error=False, fill_value='extrapolate')
+            interpfunc = interpolate.interp1d(data_times, data[:, data_idx], kind='linear', bounds_error=False, fill_value=fill_value)
             out[:, data_idx] = interpfunc(out_times)
         return out
     else:
-        interpfunc = interpolate.interp1d(data_times, data, kind='linear', bounds_error=False, fill_value='extrapolate')
+        interpfunc = interpolate.interp1d(data_times, data, kind='linear', bounds_error=False, fill_value=fill_value)
         return interpfunc(out_times)


### PR DESCRIPTION
In the case of missing data, setting fill_value to nan may be preferable. So I suggest adding an option to set fill_value from interpol instead of having this function always extrapolates.