### PR TITLE
Python 3.8-compatible type hinting

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-latest]
         #os: [ubuntu-latest]
         #os: [windows-latest]
-        python-version: [3.11]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/pyspedas/themis/state/spinmodel/spinmodel.py
+++ b/pyspedas/themis/state/spinmodel/spinmodel.py
@@ -1,6 +1,7 @@
 import numpy as np
 import math
 import logging
+from typing import Dict
 from .spinmodel_segment import SpinmodelSegment
 from pytplot import get_data, store_data
 from pytplot import data_exists
@@ -628,7 +629,7 @@ class Spinmodel:
 # and the values are Spinmodel objects.  Spinmodel objects are added to the dictionary by the
 # spinmodel_postprocess routine.
 
-spinmodel_dict: dict[(str, int)] = {}
+spinmodel_dict: Dict[(str, int)] = {}
 
 
 def get_spinmodel(probe: str,


### PR DESCRIPTION
Replaces "dict" with "Dict" in spinmodel module type hint for backward compatibility
Uses Python 3.8 for testing