### PR TITLE
Add STEREO beacon data, unit test, add assertion error for an instrument passed to stereo load

### DIFF
--- a/pyspedas/stereo/README.md
+++ b/pyspedas/stereo/README.md
@@ -5,6 +5,8 @@ The routines in this module can be used to load data from the STEREO mission.
 ### Instruments
 - Magnetometer (MAG)
 - PLAsma and SupraThermal Ion Composition (PLASTIC) 
+- STEREO Electromagnetic Waves Experiement (SWAVES)
+- Beacon (low resolution beacon data)
 
 ### Examples
 Get started by importing pyspedas and tplot; these are required to load and plot the data:
@@ -71,4 +73,11 @@ tplot(['proton_number_density', 'proton_bulk_speed', 'proton_temperature', 'prot
 ```python
 hfr_vars = pyspedas.stereo.waves(trange=['2013-11-5', '2013-11-6'])
 tplot(['PSD_FLUX'])
+```
+
+#### Beacon Data
+
+```python
+beacon_vars = pyspedas.stereo.beacon(trange=['2013-11-5', '2013-11-6'])
+tplot(['MAGBField'])
 ```

--- a/pyspedas/stereo/__init__.py
+++ b/pyspedas/stereo/__init__.py
@@ -588,3 +588,66 @@ def waves(trange=['2013-11-5', '2013-11-6'],
 
     """
     return load(instrument='waves', trange=trange, probe=probe, level=level, datatype=datatype, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)
+
+def beacon(trange=['2013-11-5', '2013-11-6'],
+        probe='a',
+        suffix='',  
+        get_support_data=False, 
+        varformat=None,
+        varnames=[],
+        downloadonly=False,
+        notplot=False,
+        no_update=False,
+        time_clip=False):
+    """
+    This function loads data from the WAVES instrument
+    
+    Parameters
+    ----------
+        trange : list of str
+            time range of interest [starttime, endtime] with the format 
+            'YYYY-MM-DD','YYYY-MM-DD'] or to specify more or less than a day 
+            ['YYYY-MM-DD/hh:mm:ss','YYYY-MM-DD/hh:mm:ss']
+
+        probe: str
+            Spacecraft probe ('a' for ahead, 'b' for behind)
+
+        datatype: str
+            Data type; Valid options: hfr, lfr
+
+        suffix: str
+            The tplot variable names will be given this suffix.  By default, 
+            no suffix is added.
+
+        get_support_data: bool
+            Data with an attribute "VAR_TYPE" with a value of "support_data"
+            will be loaded into tplot.  By default, only loads in data with a 
+            "VAR_TYPE" attribute of "data".
+
+        varformat: str
+            The file variable formats to load into tplot.  Wildcard character
+            "*" is accepted.  By default, all variables are loaded in.
+
+        varnames: list of str
+            List of variable names to load (if not specified,
+            all data variables are loaded)
+
+        downloadonly: bool
+            Set this flag to download the CDF files, but not load them into 
+            tplot variables
+
+        notplot: bool
+            Return the data in hash tables instead of creating tplot variables
+
+        no_update: bool
+            If set, only load data from your local cache
+
+        time_clip: bool
+            Time clip the variables to exactly the range specified in the trange keyword
+
+    Returns
+    ----------
+        List of tplot variables created.
+
+    """
+    return load(instrument='beacon', trange=trange, probe=probe, suffix=suffix, get_support_data=get_support_data, varformat=varformat, varnames=varnames, downloadonly=downloadonly, notplot=notplot, time_clip=time_clip, no_update=no_update)

--- a/pyspedas/stereo/load.py
+++ b/pyspedas/stereo/load.py
@@ -28,6 +28,11 @@ def load(trange=['2013-11-5', '2013-11-6'],
     """
 
     out_files = []
+    all_instr = ['mag','plastic','swea','ste', 
+                 'sept', 'sit', 'let', 'het',
+                 'waves', 'beacon'
+                 ]
+    assert instrument in all_instr, f"Instrument {instrument} not in {all_instr}"
 
     if not isinstance(probe, list):
         probe = [probe]
@@ -59,6 +64,9 @@ def load(trange=['2013-11-5', '2013-11-6'],
         elif instrument == "waves" :
             CONFIG['remote_data_dir'] = 'https://spdf.gsfc.nasa.gov/pub/data/stereo/'
             pathformat = direction + '/' + level + '/waves/' + datatype + f'/%Y/st{prb}_' + level + '_wav_' + datatype + '_%Y%m%d_v??.cdf'
+        elif instrument == 'beacon':
+            CONFIG['remote_data_dir'] = 'https://spdf.gsfc.nasa.gov/pub/data/stereo/'
+            pathformat = direction + '/' + instrument + f'/%Y/st{prb}_lb_impact_'+'%Y%m%d_v??.cdf'
 
         # find the full remote path names using the trange
         remote_names = dailynames(file_format=pathformat, trange=trange)

--- a/pyspedas/stereo/tests/tests.py
+++ b/pyspedas/stereo/tests/tests.py
@@ -57,6 +57,13 @@ class LoadTestCases(unittest.TestCase):
         self.assertTrue(data_exists('PSD_FLUX'))
         self.assertTrue(data_exists('PSD_SFU'))
 
+    def test_load_beacon_data_a(self):
+        w_vars = pyspedas.stereo.beacon(trange=['2013-11-5', '2013-11-6'], probe='a')
+        self.assertTrue(data_exists('MAGBField'))
+
+    def test_load_beacon_data_b(self):
+        w_vars = pyspedas.stereo.beacon(trange=['2013-11-5', '2013-11-6'], probe='b')
+        self.assertTrue(data_exists('MAGBField'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add `pyspedas.stereo.beacon` to enable downloading lightweight beacon data from https://spdf.gsfc.nasa.gov/pub/data/stereo/ahead/beacon/ 

Adds remote path specification in `pyspedas.stereo.load` for `instrument='beacon'`

Adds tests to check the download proceeds for probe='a' or 'b'

Also adds an assertion in `pyspedas.stereo.load` that "instrument" is in the subset for which paths are defined, otherwise raises assertion error