### PR TITLE
Disabling the HAPI tests, due to the CDAWeb HAPI server being offline…

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -107,7 +107,7 @@ jobs:
         coverage run -a -m pyspedas.cnofs.tests.tests
         coverage run -a -m pyspedas.secs.tests.tests
         coverage run -a -m pyspedas.sosmag.tests.tests
-        coverage run -a -m pyspedas.hapi.tests.tests
+        # coverage run -a -m pyspedas.hapi.tests.tests
         coverage run -a -m pyspedas.mms.tests.cotrans
         coverage run -a -m pyspedas.mms.tests.events
         coverage run -a -m pyspedas.mms.tests.orbit_plots


### PR DESCRIPTION
… temporarily