### PR TITLE
Disabling checks for Solar Orbiter RPW FLUX_DENSITY# variables (these…

### DIFF
--- a/pyspedas/solo/tests/tests.py
+++ b/pyspedas/solo/tests/tests.py
@@ -29,8 +29,8 @@ class LoadTestCases(unittest.TestCase):
         rpw_vars = pyspedas.solo.rpw()
         self.assertTrue(data_exists('AVERAGE_NR'))
         self.assertTrue(data_exists('TEMPERATURE'))
-        self.assertTrue(data_exists('FLUX_DENSITY1'))
-        self.assertTrue(data_exists('FLUX_DENSITY2'))
+        # self.assertTrue(data_exists('FLUX_DENSITY1'))
+        # self.assertTrue(data_exists('FLUX_DENSITY2'))
 
     def test_load_swa_data(self):
         swa_vars = pyspedas.solo.swa()


### PR DESCRIPTION
… variables no longer exist in the v05 CDFs