### PR TITLE
Fix PSP/SWEAP/SPC non-public data

### DIFF
--- a/pyspedas/psp/load.py
+++ b/pyspedas/psp/load.py
@@ -103,12 +103,16 @@ def load(trange=['2018-11-5', '2018-11-6'],
             file_resolution = 6*3600.
 
     elif instrument == 'spc':
-        prefix = 'psp_spc_'
         if username is None:
+            prefix = 'psp_spc_'
             pathformat = 'sweap/spc/' + level + '/' + datatype + '/%Y/psp_swp_spc_' + datatype + '_%Y%m%d_v??.cdf'
         else:
             # unpublished data
-            pathformat = 'sweap/spc/' + level + '/%Y/%m/psp_swp_spc_' + datatype + '_%Y%m%d_v0?.cdf'
+            # spc pre-public data is prepended by "spp", not "psp"
+            # The psp_ files are located in the same directory after public release
+            # but in that case users can just use the public (spdf) option. 
+            prefix = 'spp_spc_'
+            pathformat = 'sweap/spc/' + level + '/%Y/%m/spp_swp_spc_' + datatype + '_%Y%m%d_v0?.cdf'
     elif instrument == 'spe':
         prefix = 'psp_spe_'
         pathformat = 'sweap/spe/' + level + '/' + datatype + '/%Y/psp_swp_sp?_*_%Y%m%d_v??.cdf'


### PR DESCRIPTION
Change the filename pattern for non-public SPC data from starting with `psp_` to starting with `spp_`

The pre-public SPC data is recorded with the latter filename, and then changed to psp_ for the public version. If accessing without supplying a username/password users will receive the psp_ version unchanged.