### PR TITLE
Fixed import

### DIFF
--- a/pyspedas/version.py
+++ b/pyspedas/version.py
@@ -11,6 +11,6 @@ def version():
     None.
 
     """
-    from importlib_metadata import version
+    from importlib.metadata import version
     ver = version("pyspedas")
     logging.info("pyspedas version: " + ver)


### PR DESCRIPTION
Since version 3.8 importlib is part of python.

https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata

Also note that python 3.7 has reached end-of-life: https://devguide.python.org/versions/