### PR TITLE
Removed type hint

### DIFF
--- a/pyspedas/noaa/noaa_load_kp.py
+++ b/pyspedas/noaa/noaa_load_kp.py
@@ -92,7 +92,7 @@ def load_kp_to_tplot(trange=[0, 0], files=[], datatype=[]):
         This function does not return a value but downloads and processes data.
         Data is saved in a tplot variable.
     """
-    vars: list[str] = []
+    vars = []
 
     if files is None or len(files) == 0:
         logging.error("No files specified")


### PR DESCRIPTION
Type hint is not necessary and it might not be compatible with older versions of python.
