### PR TITLE
updated location for 'rfs_lfr_qtn' data

### DIFF
--- a/pyspedas/psp/load.py
+++ b/pyspedas/psp/load.py
@@ -152,7 +152,7 @@ def load(trange=['2018-11-5', '2018-11-6'],
         elif datatype == 'sqtn_rfs_v1v2':
             pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m%d_v?.?.cdf'        
         elif datatype == 'rfs_lfr_qtn':
-            pathformat = instrument + '/' + level + '/' + datatype + '/%Y/psp_fld_' + level + '_' + datatype + '_%Y%m*_v??.cdf'
+            pathformat = instrument + '/' + level + '/' + datatype + '/psp_fld_' + level + '_' + datatype + '_%Y%m*_v??.cdf'
         elif datatype in ['dfb_dc_spec', 'dfb_ac_spec', 'dfb_dc_xspec', 'dfb_ac_xspec']:
             out_vars = []
             for item in spec_types:
@@ -207,6 +207,8 @@ def load(trange=['2018-11-5', '2018-11-6'],
         # Files on Berkeley server are stored in monthly directories 
         if username != None:
             pathformat = pathformat.replace('/%Y/psp_fld', '/%Y/%m/psp_fld')
+            if datatype == 'rfs_lfr_qtn':
+                pathformat = pathformat.replace('l3/rfs_lfr_qtn/', 'l3/rfs_lfr_qtn/%Y/%m/')
             if level == 'l1':
                 pathformat = pathformat.replace('psp_fld', 'spp_fld')
 


### PR DESCRIPTION
The location of the 'rfs_lfr_qtn' data on the CDAWeb server has been updated to: https://spdf.gsfc.nasa.gov/pub/data/psp/fields/l3/rfs_lfr_qtn/

This fix points to the new location (also the corresponding location on the SSL server).

```
import pyspedas
from pytplot import tplot, options

pyspedas.psp.fields(trange=['2022-05-15','2022-06-15'],
                    datatype='rfs_lfr_qtn',level = 'l3', 
                    get_support_data=True, time_clip=True)

options('N_elec', 'ylog', True)

tplot(['N_elec'])
```