### PR TITLE
mth5 documentation fix

### DIFF
--- a/docs/source/mth5.rst
+++ b/docs/source/mth5.rst
@@ -15,7 +15,7 @@ MTH5 package is not included as a default dependency in PySPEDAS. To use this mo
 
 Load FDSN data
 ----------------------------------------------------------
-.. autofunction:: pyspedas.mth5.load_fdsn
+.. autofunction:: pyspedas.mth5.load_fdsn.load_fdsn
 
 Example
 ^^^^^^^^^


### PR DESCRIPTION
This pull request changes just one line in 'mth5.rst' to make load_fdsn function documentation been rendered correctly.
I checked it via locally installed Sphinx. Hopefully, the online documentation will be rendered automatically.