### PR TITLE
Added version checking to avoid deprecation warning in load_csa (#883)

### DIFF
--- a/pyspedas/cluster/load_csa.py
+++ b/pyspedas/cluster/load_csa.py
@@ -15,6 +15,7 @@ from pytplot import time_double
 from pytplot import cdf_to_tplot
 
 import requests
+import sys
 import tarfile
 import os
 from pathlib import Path
@@ -210,7 +211,10 @@ def load_csa(trange:List[str]=['2001-02-01', '2001-02-03'],
     # Extract the tar archive.
     tar = tarfile.open(out_gz, "r:gz")
     f = tar.getnames()
-    tar.extractall(path=local_path)
+    if sys.version_info >= (3, 12):
+        tar.extractall(path=local_path, filter='fully_trusted')
+    else:
+        tar.extractall(path=local_path)
     tar.close()
     # Remove the tar.gz file but keep the extracted.
     os.remove(out_gz)


### PR DESCRIPTION
Added version checking as described by #883 . I'm working under the assumption that 'fully_trusted' is correct here, as documentation tells me that matches the functionality of previous versions of python. 

If there are any issues, please let me know and I'll do my best to fix. 