### PR TITLE
Changed the prefix of GOES variables

### DIFF
--- a/pyspedas/goes/load.py
+++ b/pyspedas/goes/load.py
@@ -3,120 +3,71 @@ from pyspedas.utilities.download import download
 from pytplot import time_clip as tclip
 from pytplot import netcdf_to_tplot
 
-from .config import CONFIG
+from pyspedas.goes.config import CONFIG
 
 
 def loadr(
-    trange=["2023-01-01", "2032-01-02"],
-    probe="16",
+    trange=["2023-01-01", "2023-01-02 11:59:59"],
+    probe="18",
     instrument="mag",
     datatype="1min",
     prefix="",
     suffix="",
     downloadonly=False,
     no_update=False,
-    time_clip=False,
+    time_clip=True,
     force_download=False,
 ):
     """
-    This function loads GOES-R L2 data (GOES-16, GOES-17, GOES-18)
+    Loads GOES-R L2 data (GOES-16 and later) for specified instruments and data types.
 
     Parameters
     ----------
-        trange : list of str
-            time range of interest [starttime, endtime] with the format
-            'YYYY-MM-DD','YYYY-MM-DD'] or to specify more or less than a day
-            ['YYYY-MM-DD/hh:mm:ss','YYYY-MM-DD/hh:mm:ss']
-
-        probe: str/int or list of strs/ints
-            GOES spacecraft #, e.g., probe=16
-
-        instrument: str
-            name of the instrument (euvs, xrs, mag, mpsh, sgps)
-
-        datatype: str
-            Data resolution, default is '1min'
-            Valid options: low (avg), hi (full), and various other options depending on instrument
-
-        prefix: str
-            The tplot variable names will be given this prefix.
-            By default, no prefix is added.
-            If 'probename' then the name will be used, for example 'g16_'.
-
-        suffix: str
-            The tplot variable names will be given this suffix.
-            By default, no suffix is added.
-
-        downloadonly: bool
-            Set this flag to download the CDF files, but not load them into
-            tplot variables
-
-        no_update: bool
-            If set, only load data from your local cache
-
-        time_clip: bool
-            Time clip the variables to exactly the range specified in the trange keyword
-
-        force_download: bool
-            Download file even if local version is more recent than server version
-            Default: False
-
+    trange : list of str
+        Time range of interest [starttime, endtime].
+    probe : str or int or list of str or int
+        GOES spacecraft number(s), e.g., probe=16 or probe=[16, 17].
+    instrument : str or list of str
+        Name of the instrument (e.g., 'euvs', 'xrs', 'mag', 'mpsh', 'sgps').
+    datatype : str, optional
+        Data resolution, default is '1min'. Valid options: 'low' (avg), 'hi' (full), among others depending on the instrument.
+    prefix : str, optional
+        Prefix to add to the tplot variable names. Defaults to an empty string.
+    suffix : str, optional
+        Suffix to add to the tplot variable names. Defaults to an empty string.
+    downloadonly : bool, optional
+        If True, downloads the CDF files without loading them into tplot variables. Default is False.
+    no_update : bool, optional
+        If True, only loads data from the local cache. Default is False.
+    time_clip : bool, optional
+        If True (the default), clips the variables to exactly the range specified in the trange keyword.
+    force_download : bool, optional
+        If True, downloads the file even if a newer version exists locally. Default is False.
 
     Returns
     -------
-        List of tplot variables created. Or list of filenames downloaded.
+    list
+        List of tplot variables created or list of filenames downloaded.
 
     Notes
     -----
-
-    Information: https://www.ngdc.noaa.gov/stp/satellite/goes-r.html
-    Data: https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes/
-    Path: goesNN/l2/data/instrument/YYYY/MM/file.nc
-    Time variable: 'time', seconds since 2000-01-01 12:00:00
-
-    GOES-EAST (GOES-16, 2017-)
-    GOES-WEST (GOES-17, 2018-2022; GOES-18, 2023-)
-
-    Instruments:
-
-                    euvs (hi, full, 1min, euvs-l2-avg1m_science/2021/05/sci_euvs-l2-avg1m_g16_d20210530_v1-0-3.nc)
-                    euvs (low, avg, 1day, euvs-l2-avg1d_science/2021/06/sci_euvs-l2-avg1d_g16_d20210630_v1-0-3.nc)
-                    xrs  (hi, full, 1sec, xrsf-l2-flx1s_science/2022/08/sci_xrsf-l2-flx1s_g16_d20220830_v2-1-0.nc)
-                    xrs  (low, avg, 1min, xrsf-l2-avg1m_science/2021/06/sci_xrsf-l2-avg1m_g16_d20210630_v2-1-0.nc)
-                    mag  (hi, full, 0.1sec, magn-l2-hires/2021/06/dn_magn-l2-hires_g16_d20210629_v1-0-1.nc)
-                    mag  (low, avg, 1min, magn-l2-avg1m/2022/12/dn_magn-l2-avg1m_g16_d20221230_v2-0-2.nc)
-                    mpsh (hi, full, 1min, mpsh-l2-avg1m/2022/12/sci_mpsh-l2-avg1m_g16_d20221230_v2-0-0.nc)
-                    mpsh (low, avg, 5min, mpsh-l2-avg5m/2022/12/sci_mpsh-l2-avg5m_g16_d20221230_v2-0-0.nc)
-                    sgps (hi, full, 1min, sgps-l2-avg1m/2022/12/sci_sgps-l2-avg1m_g17_d20221230_v3-0-0.nc)
-                    sgps (low, avg, 5min, sgps-l2-avg5m/2022/12/sci_sgps-l2-avg5m_g17_d20221230_v3-0-0.nc)
-
-    EXIS (Extreme Ultraviolet and X-ray Sensors), EUVS and XRS
-    EUVS: Spectral line irradiances, the Mg II index, and proxy spectra from the EXIS Extreme Ultraviolet Sensor (EUVS)
-    EUVS: Daily averages of spectral line irradiances, the Mg II index, and proxy spectra
-    XRS: 1-minute averages of XRS measurements
-    XRS: High cadence measurements from the EXIS X-Ray Sensor (XRS)
-    MAG (Magnetometer)
-    MAG: Full resolution magnetic field readings in different coordinate systems
-    MAG: Averages of 10 Hz magnetometer field readings
-    SEISS (Space Environment In Situ Suite): 1-min and 5-min averages for the Magnetospheric Particle Sensors (MPS-HI and MPS-LO)
-    and for the Solar and Galactic Proton Sensor (SGPS)
-
-    Wrappers:
-
-        pyspedas.goes.euvs
-        pyspedas.goes.xrs
-        pyspedas.goes.mag
-        pyspedas.goes.mpsh
-        pyspedas.goes.sgps
+    - Information can be found at https://www.ngdc.noaa.gov/stp/satellite/goes-r.html.
+    - Data is available at https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes/.
+    - Path format: goesNN/l2/data/instrument/YYYY/MM/file.nc.
+    - Time variable is 'time', seconds since 2000-01-01 12:00:00.
+    - GOES-EAST (GOES-16, 2017-), GOES-WEST (GOES-17, 2018-2022; GOES-18, 2023-).
 
     Examples
     --------
-
-       >>> from pyspedas.goes import load
-       >>> trange = ['2023-01-01', '2023-01-02']
-       >>> load(trange=trange, probe='16', instrument='mag', datatype='1min', time_clip=True)
-
+    >>> from pyspedas.goes import load
+    >>> trange = ['2023-01-01', '2023-01-02']
+    >>> vars = load(trange=trange, probe='16', instrument='mag', datatype='1min', time_clip=True)
+    >>> print(vars)
+    ['g16_mag_DQF', 'g16_mag_b_brf', 'g16_mag_b_eci', 'g16_mag_b_epn', 'g16_mag_b_gse',
+    'g16_mag_b_gsm', 'g16_mag_b_quality', 'g16_mag_b_total', 'g16_mag_b_vdh',
+    'g16_mag_num_points', 'g16_mag_orbit_llr_geo']
     """
+
     goes_path_dir = (
         "https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes/"
     )
@@ -124,147 +75,158 @@ def loadr(
     out_files = []
     tvars = []
 
+    if isinstance(probe, tuple):
+        probe = list(probe)
     if not isinstance(probe, list):
         probe = [probe]
+    probe = [str(p) for p in probe]
+    if not isinstance(instrument, list):
+        instrument = [instrument]
 
     for prb in probe:
         remote_path = "goes" + str(prb) + "/l2/data/"
+        pathformat = []
 
-        if instrument == "euvs":
-            if datatype in ["full", "hi", "1min", "avg1m"]:  # high resolution 1 min
-                pathformat = [
-                    remote_path
-                    + "euvs-l2-avg1m_science/%Y/%m/sci_euvs-l2-avg1m_g"
-                    + str(prb)
-                    + "_d%Y%m%d_v?-?-?.nc"
-                ]
-            else:  # low resolution 1 day, smaller files
-                pathformat = [
-                    remote_path
-                    + "euvs-l2-avg1d_science/%Y/%m/sci_euvs-l2-avg1d_g"
-                    + str(prb)
-                    + "_d%Y%m%d_v?-?-?.nc"
-                ]
-        elif instrument == "xrs":
-            if datatype in ["full", "hi", "1sec", "flx1s"]:  # high resolution 1 sec
-                pathformat = [
-                    remote_path
-                    + "xrsf-l2-flx1s_science/%Y/%m/sci_xrsf-l2-flx1s_g"
-                    + str(prb)
-                    + "_d%Y%m%d_v?-?-?.nc"
-                ]
-            else:  # low resolution 1 min, smaller files
-                pathformat = [
-                    remote_path
-                    + "xrsf-l2-avg1m_science/%Y/%m/sci_xrsf-l2-avg1m_g"
-                    + str(prb)
-                    + "_d%Y%m%d_v?-?-?.nc"
-                ]
-        elif instrument == "mag":
-            if datatype in ["full", "hi", "0.1sec", "hires"]:  # high resolution 0.1 sec
-                pathformat = [
-                    remote_path
-                    + "magn-l2-hires/%Y/%m/dn_magn-l2-hires_g"
-                    + str(prb)
-                    + "_d%Y%m%d_v?-?-?.nc"
-                ]
-            else:  # low resolution 1 min, smaller files
-                pathformat = [
-                    remote_path
-                    + "magn-l2-avg1m/%Y/%m/dn_magn-l2-avg1m_g"
-                    + str(prb)
-                    + "_d%Y%m%d_v?-?-?.nc"
-                ]
-        elif instrument == "mpsh":
-            time_var = "L2_SciData_TimeStamp"
-            if datatype in [
-                "full",
-                "hi",
-                "1min",
-                "avg1m",
-                "1m",
-            ]:  # high resolution 1 min
-                pathformat = [
-                    remote_path
-                    + "mpsh-l2-avg1m/%Y/%m/sci_mpsh-l2-avg1m_g"
-                    + str(prb)
-                    + "_d%Y%m%d_v?-?-?.nc"
-                ]
-            else:  # low resolution 5 min, smaller files
-                pathformat = [
-                    remote_path
-                    + "mpsh-l2-avg5m/%Y/%m/sci_mpsh-l2-avg5m_g"
-                    + str(prb)
-                    + "_d%Y%m%d_v?-?-?.nc"
-                ]
-        elif instrument == "sgps":
-            if datatype in [
-                "full",
-                "hi",
-                "1min",
-                "avg1m",
-                "1m",
-            ]:  # high resolution 1 min
-                pathformat = [
-                    remote_path
-                    + "sgps-l2-avg1m/%Y/%m/sci_sgps-l2-avg1m_g"
-                    + str(prb)
-                    + "_d%Y%m%d_v?-?-?.nc"
-                ]
-            else:  # low resolution 5 min, smaller files
-                pathformat = [
-                    remote_path
-                    + "sgps-l2-avg5m/%Y/%m/sci_sgps-l2-avg5m_g"
-                    + str(prb)
-                    + "_d%Y%m%d_v?-?-?.nc"
-                ]
+        for instr in instrument:
+            if instr == "euvs":
+                if datatype in ["full", "hi", "1min", "avg1m"]:  # high resolution 1 min
+                    pathformat = [
+                        remote_path
+                        + "euvs-l2-avg1m_science/%Y/%m/sci_euvs-l2-avg1m_g"
+                        + str(prb)
+                        + "_d%Y%m%d_v?-?-?.nc"
+                    ]
+                else:  # low resolution 1 day, smaller files
+                    pathformat = [
+                        remote_path
+                        + "euvs-l2-avg1d_science/%Y/%m/sci_euvs-l2-avg1d_g"
+                        + str(prb)
+                        + "_d%Y%m%d_v?-?-?.nc"
+                    ]
+            elif instr == "xrs":
+                if datatype in ["full", "hi", "1sec", "flx1s"]:  # high resolution 1 sec
+                    pathformat = [
+                        remote_path
+                        + "xrsf-l2-flx1s_science/%Y/%m/sci_xrsf-l2-flx1s_g"
+                        + str(prb)
+                        + "_d%Y%m%d_v?-?-?.nc"
+                    ]
+                else:  # low resolution 1 min, smaller files
+                    pathformat = [
+                        remote_path
+                        + "xrsf-l2-avg1m_science/%Y/%m/sci_xrsf-l2-avg1m_g"
+                        + str(prb)
+                        + "_d%Y%m%d_v?-?-?.nc"
+                    ]
+            elif instr == "mag":
+                if datatype in [
+                    "full",
+                    "hi",
+                    "0.1sec",
+                    "hires",
+                ]:  # high resolution 0.1 sec
+                    pathformat = [
+                        remote_path
+                        + "magn-l2-hires/%Y/%m/dn_magn-l2-hires_g"
+                        + str(prb)
+                        + "_d%Y%m%d_v?-?-?.nc"
+                    ]
+                else:  # low resolution 1 min, smaller files
+                    pathformat = [
+                        remote_path
+                        + "magn-l2-avg1m/%Y/%m/dn_magn-l2-avg1m_g"
+                        + str(prb)
+                        + "_d%Y%m%d_v?-?-?.nc"
+                    ]
+            elif instr == "mpsh":
+                time_var = "L2_SciData_TimeStamp"
+                if datatype in [
+                    "full",
+                    "hi",
+                    "1min",
+                    "avg1m",
+                    "1m",
+                ]:  # high resolution 1 min
+                    pathformat = [
+                        remote_path
+                        + "mpsh-l2-avg1m/%Y/%m/sci_mpsh-l2-avg1m_g"
+                        + str(prb)
+                        + "_d%Y%m%d_v?-?-?.nc"
+                    ]
+                else:  # low resolution 5 min, smaller files
+                    pathformat = [
+                        remote_path
+                        + "mpsh-l2-avg5m/%Y/%m/sci_mpsh-l2-avg5m_g"
+                        + str(prb)
+                        + "_d%Y%m%d_v?-?-?.nc"
+                    ]
+            elif instr == "sgps":
+                if datatype in [
+                    "full",
+                    "hi",
+                    "1min",
+                    "avg1m",
+                    "1m",
+                ]:  # high resolution 1 min
+                    pathformat = [
+                        remote_path
+                        + "sgps-l2-avg1m/%Y/%m/sci_sgps-l2-avg1m_g"
+                        + str(prb)
+                        + "_d%Y%m%d_v?-?-?.nc"
+                    ]
+                else:  # low resolution 5 min, smaller files
+                    pathformat = [
+                        remote_path
+                        + "sgps-l2-avg5m/%Y/%m/sci_sgps-l2-avg5m_g"
+                        + str(prb)
+                        + "_d%Y%m%d_v?-?-?.nc"
+                    ]
 
-        # find the full remote path names using the trange
-        if not isinstance(pathformat, list):
-            pathformat = [pathformat]
+            # find the full remote path names using the trange
+            if not isinstance(pathformat, list):
+                pathformat = [pathformat]
 
-        remote_names = []
-        for path in pathformat:
-            remote_names.extend(dailynames(file_format=path, trange=trange))
+            remote_names = []
+            for path in pathformat:
+                remote_names.extend(dailynames(file_format=path, trange=trange))
 
-        files = download(
-            remote_file=remote_names,
-            remote_path=goes_path_dir,
-            local_path=CONFIG["local_data_dir"],
-            no_download=no_update,
-            force_download=force_download
-        )
-
-        if files is not None:
-            for file in files:
-                out_files.append(file)
-
-        tvars_local = []
-        if len(files) > 0 and downloadonly is False:
-            if prefix == "probename":
-                prefix_local = "g" + str(prb) + "_"
-            else:
-                prefix_local = prefix
-            tvars_local = netcdf_to_tplot(
-                files, prefix=prefix_local, suffix=suffix, merge=True, time=time_var
+            # For each probe and instrument, download the files
+            files = download(
+                remote_file=remote_names,
+                remote_path=goes_path_dir,
+                local_path=CONFIG["local_data_dir"],
+                no_download=no_update,
+                force_download=force_download,
             )
 
-        if len(tvars_local):
-            tvars.extend(tvars_local)
+            files = sorted(set(files))
+            out_files.extend(files)
+
+            if len(files) > 0 and not downloadonly:
+                if prefix is None or prefix == "" or prefix == "probename":
+                    # Example of prefix: g16_xrs_
+                    prefix_local = "g" + str(prb) + "_" + instr + "_"
+                else:
+                    prefix_local = prefix
+
+                # Load all files from the same probe and instrument, merging them
+                tvars_local = netcdf_to_tplot(
+                    files, prefix=prefix_local, suffix=suffix, time=time_var
+                )
+                if len(tvars_local) > 0:
+                    tvars.extend(tvars_local)
+                    if time_clip:
+                        tclip(tvars_local, trange[0], trange[1], overwrite=True)
 
     if downloadonly:
-        out_files = sorted(out_files)
         return out_files
 
-    if time_clip:
-        for new_var in tvars:
-            tclip(new_var, trange[0], trange[1], suffix="")
-
+    tvars = sorted(set(tvars))
     return tvars
 
 
 def load(
-    trange=["2013-11-05", "2013-11-06"],
+    trange=["2013-11-05", "2013-11-06 12:00:00"],
     probe="15",
     instrument="fgm",
     datatype="1min",
@@ -272,79 +234,62 @@ def load(
     suffix="",
     downloadonly=False,
     no_update=False,
-    time_clip=False,
+    time_clip=True,
     force_download=False,
 ):
     """
-    This function loads GOES L2 data
+    Load GOES L2 data.
 
     Parameters
     ----------
-
-        trange : list of str
-            time range of interest [starttime, endtime] with the format
-            'YYYY-MM-DD','YYYY-MM-DD'] or to specify more or less than a day
-            ['YYYY-MM-DD/hh:mm:ss','YYYY-MM-DD/hh:mm:ss']
-
-        probe: str/int or list of strs/ints
-            GOES spacecraft #, e.g., probe=15
-
-        instrument: str
-            name of the instrument::
-
-                (for GOES 8-15: fgm, eps, epead, maged, magpd, hepad, xrs)
-                (for GOES-R 16-18: euvs, xrs, mag, mpsh, sgps)
-
-        datatype: str
-            Data type; usually instrument resolution, depends on the instrument (default '1min')::
-
-                (valid for GOES 8-15: hi, low, full, avg, 1min, 5min)
-                (valid for GOES-R 16-18: hi, low, full, avg, and other options)
-
-        prefix: str
-            The tplot variable names will be given this prefix.
-            By default, no prefix is added.
-            If prefix is 'probename' then the name will be used, for example g16.
-
-        suffix: str
-            The tplot variable names will be given this suffix.
-            By default, no suffix is added.
-
-        downloadonly: bool
-            Set this flag to download the CDF files, but not load them into
-            tplot variables
-
-        no_update: bool
-            If set, only load data from your local cache
-
-        time_clip: bool
-            Time clip the variables to exactly the range specified in the trange keyword
-
-        force_download: bool
-            Download file even if local version is more recent than server version
-            Default: False
+    trange : list of str
+        Time range of interest ['YYYY-MM-DD', 'YYYY-MM-DD'] or to specify more or less than a day
+        ['YYYY-MM-DD/hh:mm:ss', 'YYYY-MM-DD/hh:mm:ss'].
+    probe : str, int, or list of str/int
+        GOES spacecraft number(s), e.g., probe=15.
+    instrument : str or list of str
+        Name of the instrument. For GOES 8-15: 'fgm', 'eps', 'epead', 'maged', 'magpd', 'hepad', 'xrs'.
+        For GOES-R 16-18: 'euvs', 'xrs', 'mag', 'mpsh', 'sgps'.
+    datatype : str
+        Data type; usually instrument resolution, depends on the instrument (default '1min').
+        Valid for GOES 8-15: 'hi', 'low', 'full', 'avg', '1min', '5min'.
+        Valid for GOES-R 16-18: 'hi', 'low', 'full', 'avg', and other options.
+    prefix : str, optional
+        Prefix to add to the tplot variable names. By default, no prefix is added.
+        If prefix is 'probename', then the name will be used, for example, 'g16'.
+    suffix : str, optional
+        Suffix to add to the tplot variable names. By default, no suffix is added.
+    downloadonly : bool, optional
+        If True, downloads the CDF files without loading them into tplot variables. Default is False.
+    no_update : bool, optional
+        If True, only loads data from the local cache. Default is False.
+    time_clip : bool, optional
+        If True (the default), clips the variables to exactly the range specified in the trange keyword.
+    force_download : bool, optional
+        If True, downloads the file even if a newer version exists locally. Default is False.
 
     Returns
     -------
-        List of tplot variables created. Or list of filenames downloaded.
+    list of str
+        List of tplot variables created or list of filenames downloaded.
 
-    Notes
-    -----
-    This function loads data from the GOES mission; this function is not meant
-    to be called directly; instead, see the wrappers::
-
-        pyspedas.goes.fgm
-        pyspedas.goes.eps
-        pyspedas.goes.epead
-        pyspedas.goes.maged
-        pyspedas.goes.magpd
-        pyspedas.goes.hepad
-        pyspedas.goes.xrs
-
+    Examples
+    --------
+    >>> from pyspedas.goes import load
+    >>> trange = ['2019-01-01', '2019-01-02']
+    >>> vars = load(trange=trange, probe='15', instrument='fgm', datatype='1min', time_clip=True)
+    >>> print(vars)
+    ['g15_fgm_BX_1_QUAL_FLAG', 'g15_fgm_BX_1_NUM_PTS', 'g15_fgm_BX_1', ...]
+    (the result is a list of 66 variables)
     """
 
+    if isinstance(probe, tuple):
+        probe = list(probe)
     if not isinstance(probe, list):
         probe = [probe]
+    probe = [str(p) for p in probe]
+    if not isinstance(instrument, list):
+        instrument = [instrument]
 
     probe_r = []  # GOES-R probes
     probe_s = []  # GOES probes
@@ -381,153 +326,162 @@ def load(
         avg_path = "avg/%Y/%m/goes" + str(prb) + "/netcdf/" + "g" + str(prb)
         full_path = "full/%Y/%m/goes" + str(prb) + "/netcdf/" + "g" + str(prb)
 
-        if instrument == "fgm":
-            if datatype == "512ms" or datatype == "full":  # full, unaveraged data
-                pathformat = full_path + "_magneto_512ms_%Y%m%d_%Y%m%d.nc"
-            elif datatype == "5min":  # 5 min averages
-                pathformat = avg_path + "_magneto_5m_%Y%m01_%Y%m??.nc"
-            else:  # 1 min averages, goes13, goes15 only contain 1m averages
-                pathformat = avg_path + "_magneto_1m_%Y%m01_%Y%m??.nc"
-        elif instrument == "eps":
-            # energetic particle sensor -- only valid for GOES-08 through GOES-12, only averaged data available
-            if datatype == "1min" or datatype == "full":
-                pathformat = avg_path + "_eps_1m_%Y%m01_%Y%m??.nc"
-            else:  # 'low' or 5min
-                pathformat = avg_path + "_eps_5m_%Y%m01_%Y%m??.nc"
-        elif instrument == "epead":
-            # electron, proton, alpha detector -- only valid on GOES-13, 14, 15
-            if datatype == "1min":
-                pathformat = [
-                    "_epead_e13ew_1m_%Y%m01_%Y%m??.nc",
-                    "_epead_p17ew_1m_%Y%m01_%Y%m??.nc",
-                    "_epead_a16ew_1m_%Y%m01_%Y%m??.nc",
-                ]
-                pathformat = [avg_path + s for s in pathformat]
-            elif datatype == "5min" or datatype == "low":
-                pathformat = [
-                    "_epead_e13ew_5m_%Y%m01_%Y%m??.nc",
-                    "_epead_p17ew_5m_%Y%m01_%Y%m??.nc",
-                    "_epead_a16ew_5m_%Y%m01_%Y%m??.nc",
-                ]
-                pathformat = [avg_path + s for s in pathformat]
-            else:  # full
-                pathformat = [
-                    "_epead_a16e_32s_%Y%m%d_%Y%m%d.nc",
-                    "_epead_a16w_32s_%Y%m%d_%Y%m%d.nc",
-                    "_epead_e1ew_4s_%Y%m%d_%Y%m%d.nc",
-                    "_epead_e2ew_16s_%Y%m%d_%Y%m%d.nc",
-                    "_epead_e3ew_16s_%Y%m%d_%Y%m%d.nc",
-                    "_epead_p1ew_8s_%Y%m%d_%Y%m%d.nc",
-                    "_epead_p27e_32s_%Y%m%d_%Y%m%d.nc",
-                    "_epead_p27w_32s_%Y%m%d_%Y%m%d.nc",
-                ]
-                pathformat = [full_path + s for s in pathformat]
-        elif instrument == "maged":
-            # magnetospheric electron detector -- only valid on GOES 13, 14, 15
-            if datatype == "1min":
-                pathformat = avg_path + "_maged_19me15_1m_%Y%m01_%Y%m??.nc"
-            elif datatype == "5min" or datatype == "low":
-                pathformat = avg_path + "_maged_19me15_5m_%Y%m01_%Y%m??.nc"
-            else:  # full
-                channels = ["me1", "me2", "me3", "me4", "me5"]
-                resolution = ["2", "2", "4", "16", "32"]
-                pathformat = []
-                for idx, channel in enumerate(channels):
-                    pathformat.append(
-                        "_maged_19"
-                        + channel
-                        + "_"
-                        + resolution[idx]
-                        + "s_%Y%m%d_%Y%m%d.nc"
-                    )
-                pathformat = [full_path + s for s in pathformat]
-        elif instrument == "magpd":
-            # magnetospheric proton detector -- only valid on GOES 13, 14, 15
-            if datatype == "1min" or datatype == "low":
-                pathformat = avg_path + "_magpd_19mp15_1m_%Y%m01_%Y%m??.nc"
-            else:  # full
-                channels = ["mp1", "mp2", "mp3", "mp4", "mp5"]
-                resolution = ["16", "16", "16", "32", "32"]
-                pathformat = []
-                for idx, channel in enumerate(channels):
-                    pathformat.append(
-                        "_magpd_19"
-                        + channel
-                        + "_"
-                        + resolution[idx]
-                        + "s_%Y%m%d_%Y%m%d.nc"
-                    )
-                pathformat = [full_path + s for s in pathformat]
-        elif instrument == "hepad":
-            # high energy proton and alpha detector -- valid for GOES 08-15
-            if datatype == "1min":
-                pathformat = [
-                    "_hepad_ap_1m_%Y%m01_%Y%m??.nc",
-                    "_hepad_s15_1m_%Y%m01_%Y%m??.nc",
-                ]
-                pathformat = [avg_path + s for s in pathformat]
-            elif datatype == "5min" or datatype == "low":
-                pathformat = [
-                    "_hepad_ap_5m_%Y%m01_%Y%m??.nc",
-                    "_hepad_s15_5m_%Y%m01_%Y%m??.nc",
-                ]
-                pathformat = [avg_path + s for s in pathformat]
-            else:
-                pathformat = [
-                    "_hepad_ap_32s_%Y%m%d_%Y%m%d.nc",
-                    "_hepad_s15_4s_%Y%m%d_%Y%m%d.nc",
-                ]
-                pathformat = [full_path + s for s in pathformat]
-        elif instrument == "xrs":
-            # x-ray sensor -- valid for GOES 08-15
-            if datatype == "1min":
-                pathformat = avg_path + "_xrs_1m_%Y%m01_%Y%m??.nc"
-            elif datatype == "5min" or datatype == "low":
-                pathformat = avg_path + "_xrs_5m_%Y%m01_%Y%m??.nc"
-            else:
-                pathformat = ["_xrs_2s_%Y%m%d_%Y%m%d.nc", "_xrs_3s_%Y%m%d_%Y%m%d.nc"]
-                pathformat = [full_path + s for s in pathformat]
+        for instr in instrument:
+            pathformat = []
+            if instr == "fgm":
+                if datatype == "512ms" or datatype == "full":  # full, unaveraged data
+                    pathformat = full_path + "_magneto_512ms_%Y%m%d_%Y%m%d.nc"
+                elif datatype == "5min":  # 5 min averages
+                    pathformat = avg_path + "_magneto_5m_%Y%m01_%Y%m??.nc"
+                else:  # 1 min averages, goes13, goes15 only contain 1m averages
+                    pathformat = avg_path + "_magneto_1m_%Y%m01_%Y%m??.nc"
+            elif instr == "eps":
+                # energetic particle sensor -- only valid for GOES-08 through GOES-12, only averaged data available
+                if datatype == "1min" or datatype == "full":
+                    pathformat = avg_path + "_eps_1m_%Y%m01_%Y%m??.nc"
+                else:  # 'low' or 5min
+                    pathformat = avg_path + "_eps_5m_%Y%m01_%Y%m??.nc"
+            elif instr == "epead":
+                # electron, proton, alpha detector -- only valid on GOES-13, 14, 15
+                if datatype == "1min":
+                    pathformat = [
+                        "_epead_e13ew_1m_%Y%m01_%Y%m??.nc",
+                        "_epead_p17ew_1m_%Y%m01_%Y%m??.nc",
+                        "_epead_a16ew_1m_%Y%m01_%Y%m??.nc",
+                    ]
+                    pathformat = [avg_path + s for s in pathformat]
+                elif datatype == "5min" or datatype == "low":
+                    pathformat = [
+                        "_epead_e13ew_5m_%Y%m01_%Y%m??.nc",
+                        "_epead_p17ew_5m_%Y%m01_%Y%m??.nc",
+                        "_epead_a16ew_5m_%Y%m01_%Y%m??.nc",
+                    ]
+                    pathformat = [avg_path + s for s in pathformat]
+                else:  # full
+                    pathformat = [
+                        "_epead_a16e_32s_%Y%m%d_%Y%m%d.nc",
+                        "_epead_a16w_32s_%Y%m%d_%Y%m%d.nc",
+                        "_epead_e1ew_4s_%Y%m%d_%Y%m%d.nc",
+                        "_epead_e2ew_16s_%Y%m%d_%Y%m%d.nc",
+                        "_epead_e3ew_16s_%Y%m%d_%Y%m%d.nc",
+                        "_epead_p1ew_8s_%Y%m%d_%Y%m%d.nc",
+                        "_epead_p27e_32s_%Y%m%d_%Y%m%d.nc",
+                        "_epead_p27w_32s_%Y%m%d_%Y%m%d.nc",
+                    ]
+                    pathformat = [full_path + s for s in pathformat]
+            elif instr == "maged":
+                # magnetospheric electron detector -- only valid on GOES 13, 14, 15
+                if datatype == "1min":
+                    pathformat = avg_path + "_maged_19me15_1m_%Y%m01_%Y%m??.nc"
+                elif datatype == "5min" or datatype == "low":
+                    pathformat = avg_path + "_maged_19me15_5m_%Y%m01_%Y%m??.nc"
+                else:  # full
+                    channels = ["me1", "me2", "me3", "me4", "me5"]
+                    resolution = ["2", "2", "4", "16", "32"]
+                    pathformat = []
+                    for idx, channel in enumerate(channels):
+                        pathformat.append(
+                            "_maged_19"
+                            + channel
+                            + "_"
+                            + resolution[idx]
+                            + "s_%Y%m%d_%Y%m%d.nc"
+                        )
+                    pathformat = [full_path + s for s in pathformat]
+            elif instr == "magpd":
+                # magnetospheric proton detector -- only valid on GOES 13, 14, 15
+                if datatype == "1min" or datatype == "low":
+                    pathformat = avg_path + "_magpd_19mp15_1m_%Y%m01_%Y%m??.nc"
+                else:  # full
+                    channels = ["mp1", "mp2", "mp3", "mp4", "mp5"]
+                    resolution = ["16", "16", "16", "32", "32"]
+                    pathformat = []
+                    for idx, channel in enumerate(channels):
+                        pathformat.append(
+                            "_magpd_19"
+                            + channel
+                            + "_"
+                            + resolution[idx]
+                            + "s_%Y%m%d_%Y%m%d.nc"
+                        )
+                    pathformat = [full_path + s for s in pathformat]
+            elif instr == "hepad":
+                # high energy proton and alpha detector -- valid for GOES 08-15
+                if datatype == "1min":
+                    pathformat = [
+                        "_hepad_ap_1m_%Y%m01_%Y%m??.nc",
+                        "_hepad_s15_1m_%Y%m01_%Y%m??.nc",
+                    ]
+                    pathformat = [avg_path + s for s in pathformat]
+                elif datatype == "5min" or datatype == "low":
+                    pathformat = [
+                        "_hepad_ap_5m_%Y%m01_%Y%m??.nc",
+                        "_hepad_s15_5m_%Y%m01_%Y%m??.nc",
+                    ]
+                    pathformat = [avg_path + s for s in pathformat]
+                else:
+                    pathformat = [
+                        "_hepad_ap_32s_%Y%m%d_%Y%m%d.nc",
+                        "_hepad_s15_4s_%Y%m%d_%Y%m%d.nc",
+                    ]
+                    pathformat = [full_path + s for s in pathformat]
+            elif instr == "xrs":
+                # x-ray sensor -- valid for GOES 08-15
+                if datatype == "1min":
+                    pathformat = avg_path + "_xrs_1m_%Y%m01_%Y%m??.nc"
+                elif datatype == "5min" or datatype == "low":
+                    pathformat = avg_path + "_xrs_5m_%Y%m01_%Y%m??.nc"
+                else:
+                    pathformat = [
+                        "_xrs_2s_%Y%m%d_%Y%m%d.nc",
+                        "_xrs_3s_%Y%m%d_%Y%m%d.nc",
+                    ]
+                    pathformat = [full_path + s for s in pathformat]
 
-        # find the full remote path names using the trange
-        if not isinstance(pathformat, list):
-            pathformat = [pathformat]
+            # find the full remote path names using the trange
+            if not isinstance(pathformat, list):
+                pathformat = [pathformat]
 
-        remote_names = []
-        for path in pathformat:
-            remote_names.extend(dailynames(file_format=path, trange=trange))
+            remote_names = []
+            for path in pathformat:
+                remote_names.extend(dailynames(file_format=path, trange=trange))
 
-        files = download(
-            remote_file=remote_names,
-            remote_path=CONFIG["remote_data_dir"],
-            local_path=CONFIG["local_data_dir"],
-            no_download=no_update,
-            force_download=force_download,
-        )
-        if files is not None:
-            for file in files:
-                out_files.append(file)
-
-        tvars_local = []
-        if len(files) > 0 and downloadonly is False:
-            if prefix == "probename":
-                prefix_local = "g" + str(prb) + "_"
-            else:
-                prefix_local = prefix
-            tvars_local = netcdf_to_tplot(
-                files, prefix=prefix_local, suffix=suffix, merge=True, time="time_tag"
+            files = download(
+                remote_file=remote_names,
+                remote_path=CONFIG["remote_data_dir"],
+                local_path=CONFIG["local_data_dir"],
+                no_download=no_update,
+                force_download=force_download,
             )
 
-        if len(tvars_local) > 0:
-            tvars.extend(tvars_local)
+            if files is not None:
+                if not isinstance(files, list):
+                    files = [files]
+                out_files.extend(files)
+
+            tvars_local = []
+            if len(files) > 0 and downloadonly is False:
+                if prefix is None or prefix == "" or prefix == "probename":
+                    # Example of prefix: g15_xrs_
+                    prefix_local = "g" + str(prb) + "_" + instr + "_"
+                else:
+                    prefix_local = prefix
+
+                tvars_local = netcdf_to_tplot(
+                    files, prefix=prefix_local, suffix=suffix, time="time_tag"
+                )
+
+                if len(tvars_local) > 0:
+                    tvars.extend(tvars_local)
+                    if time_clip:
+                        tclip(
+                            tvars_local, trange[0], trange[1], suffix="", overwrite=True
+                        )
 
     if downloadonly:
         out_files.extend(out_files_r)  # append GOES-R filenames
-        out_files = sorted(out_files)
+        out_files = sorted(set(out_files))
         return out_files
-
-    if time_clip:
-        for new_var in tvars:
-            tclip(new_var, trange[0], trange[1], suffix="")
 
     if len(tvars_r):
         tvars.extend(tvars_r)  # append GOES-R variables

--- a/pyspedas/goes/load_orbit.py
+++ b/pyspedas/goes/load_orbit.py
@@ -18,49 +18,41 @@ def load_orbit(
     notplot=False,
     no_update=False,
     time_clip=True,
+    force_download=False,
 ):
     """
-    This function loads GOES orbit data from SPDF:
+    Load GOES orbit data from SPDF.
 
+    Fetches GOES orbit data from the Space Physics Data Facility (SPDF) website:
     https://spdf.gsfc.nasa.gov/pub/data/goes/goes#/orbit/YYYY/
 
     Parameters
     ----------
-        trange : list of str
-            time range of interest [starttime, endtime] with the format
-            'YYYY-MM-DD','YYYY-MM-DD'] or to specify more or less than a day
-            ['YYYY-MM-DD/hh:mm:ss','YYYY-MM-DD/hh:mm:ss']
-
-        probe: str/int or list of strs/ints
-            GOES spacecraft #, e.g., probe=15
-
-        prefix: str
-            The tplot variable names will be given this prefix.
-            By default, no prefix is added.
-            If 'probename' then the name will be used, for example g16.
-
-        suffix: str
-            The tplot variable names will be given this suffix.
-            By default, no suffix is added.
-
-        downloadonly: bool
-            Set this flag to download the CDF files, but not load them into
-            tplot variables
-
-        notplot: bool
-            If set, load the data into dictionaries containing the numpy objects instead
-            of creating tplot variables
-
-        no_update: bool
-            If set, only load data from your local cache
-
-        time_clip: bool
-            Time clip the variables to exactly the range specified in the trange keyword
+    trange : list of str
+        Time range of interest ['YYYY-MM-DD', 'YYYY-MM-DD'].
+        Or, to specify more or less than a day: ['YYYY-MM-DD hh:mm:ss', 'YYYY-MM-DD hh:mm:ss'].
+    probe : str or int or list of str or int
+        GOES spacecraft number(s), e.g., probe=15.
+    prefix : str, optional
+        Prefix to add to the tplot variable names.
+        By default, the added prefix is 'g[probe]_orbit_'.
+    suffix : str, optional
+        Suffix to add to the tplot variable names. By default, no suffix is added.
+    downloadonly : bool, optional
+        If True, downloads the CDF files without loading them into tplot variables. Default is False.
+    notplot : bool, optional
+        If True, loads the data into dictionaries containing the numpy objects instead of creating tplot variables. Default is False.
+    no_update : bool, optional
+        If True, only loads data from the local cache. Default is False.
+    time_clip : bool, optional
+        If True, clips the variables to exactly the range specified in the trange keyword. Default is False.
+    force_download : bool, optional
+        If True, downloads the file even if a newer version exists locally. Default is False.
 
     Returns
     -------
-        List of tplot variables created. Or list of filenames downloaded.
-
+    list of str
+        List of tplot variables created or list of filenames downloaded.
     """
     remote_data_dir = "https://spdf.gsfc.nasa.gov/pub/data/goes/"
     out_files = []  # list of local files downloaded
@@ -87,6 +79,7 @@ def load_orbit(
             remote_path=remote_data_dir,
             local_path=CONFIG["local_data_dir"],
             no_download=no_update,
+            force_download=force_download,
         )
 
         out_files_local = []
@@ -99,8 +92,9 @@ def load_orbit(
 
         tvars_local = []
         if not downloadonly:
-            if prefix == "probename":
-                prefix_local = "g" + str(prb) + "_"
+            if prefix is None or prefix == "" or prefix == "probename":
+                # Example of prefix: g15_orbit_
+                prefix_local = "g" + str(prb) + "_" + "orbit_"
             else:
                 prefix_local = prefix
 
@@ -115,9 +109,8 @@ def load_orbit(
             )
             tvars.extend(tvars_local)
 
-        if time_clip:
-            for new_var in tvars_local:
-                tclip(new_var, trange[0], trange[1], suffix="")
+            if time_clip:
+                tclip(tvars_local, trange[0], trange[1], suffix="")
 
     if downloadonly:
         return out_files

--- a/pyspedas/goes/tests/tests.py
+++ b/pyspedas/goes/tests/tests.py
@@ -1,7 +1,6 @@
-
 import os
 import unittest
-from pytplot import data_exists
+from pytplot import data_exists, tnames
 
 import pyspedas
 from pytplot import del_data, tplot
@@ -11,7 +10,7 @@ class LoadTestCases(unittest.TestCase):
 
     def test_downloadonly(self):
         del_data()
-        mag_files = pyspedas.goes.fgm(datatype='1min', downloadonly=True)
+        mag_files = pyspedas.goes.fgm(datatype="1min", downloadonly=True)
         self.assertTrue(os.path.exists(mag_files[0]))
 
     def test_load_orbit_data(self):
@@ -19,300 +18,355 @@ class LoadTestCases(unittest.TestCase):
         orbit_vars = pyspedas.goes.orbit(downloadonly=True)
         orbit_vars = pyspedas.goes.orbit(notplot=True)
         orbit_vars = pyspedas.goes.orbit()
-        self.assertTrue('XYZ_GSM' in orbit_vars)
-        self.assertTrue('XYZ_GSE' in orbit_vars)
-        self.assertTrue('XYZ_SM' in orbit_vars)
-        self.assertTrue('XYZ_GEO' in orbit_vars)
+        self.assertTrue("g15_orbit_XYZ_GSM" in orbit_vars)
+        self.assertTrue("g15_orbit_XYZ_GSE" in orbit_vars)
+        self.assertTrue("g15_orbit_XYZ_SM" in orbit_vars)
+        self.assertTrue("g15_orbit_XYZ_GEO" in orbit_vars)
 
-        self.assertTrue(data_exists('XYZ_GSM'))
-        self.assertTrue(data_exists('XYZ_GSE'))
-        self.assertTrue(data_exists('XYZ_SM'))
-        self.assertTrue(data_exists('XYZ_GEO'))
+        self.assertTrue(data_exists("g15_orbit_XYZ_GSM"))
+        self.assertTrue(data_exists("g15_orbit_XYZ_GSE"))
+        self.assertTrue(data_exists("g15_orbit_XYZ_SM"))
+        self.assertTrue(data_exists("g15_orbit_XYZ_GEO"))
 
     def test_load_1min_mag_data(self):
         del_data()
-        mag_vars = pyspedas.goes.fgm(datatype='1min')
-        self.assertTrue('BX_1' in mag_vars)
-        self.assertTrue('BY_1' in mag_vars)
-        self.assertTrue('BZ_1' in mag_vars)
-        self.assertTrue(data_exists('BX_1'))
-        self.assertTrue(data_exists('BY_1'))
-        self.assertTrue(data_exists('BZ_1'))
+        mag_vars = pyspedas.goes.fgm(datatype="1min")
+        self.assertTrue("g15_fgm_BX_1" in mag_vars)
+        self.assertTrue("g15_fgm_BY_1" in mag_vars)
+        self.assertTrue("g15_fgm_BZ_1" in mag_vars)
+        self.assertTrue(data_exists("g15_fgm_BX_1"))
+        self.assertTrue(data_exists("g15_fgm_BY_1"))
+        self.assertTrue(data_exists("g15_fgm_BZ_1"))
 
     def test_load_5min_mag_data(self):
         del_data()
-        mag_vars = pyspedas.goes.fgm(datatype='5min', probe='10', trange=['2000-07-01', '2000-07-02'], time_clip=True)
-        self.assertTrue('ht' in mag_vars)
-        self.assertTrue(data_exists('ht'))
+        mag_vars = pyspedas.goes.fgm(
+            datatype="5min",
+            probe="10",
+            trange=["2000-07-01", "2000-07-02"],
+            time_clip=True,
+        )
+        self.assertTrue("g10_fgm_ht" in mag_vars)
+        self.assertTrue(data_exists("g10_fgm_ht"))
 
     def test_load_full_mag_data(self):
         del_data()
-        mag_vars = pyspedas.goes.fgm(datatype='512ms', suffix='_512')
-        self.assertTrue('BX_1_512' in mag_vars)
-        self.assertTrue('BY_1_512' in mag_vars)
-        self.assertTrue('BZ_1_512' in mag_vars)
-        self.assertTrue(data_exists('BX_1_512'))
-        self.assertTrue(data_exists('BY_1_512'))
-        self.assertTrue(data_exists('BZ_1_512'))
+        mag_vars = pyspedas.goes.fgm(datatype="512ms", suffix="_512")
+        self.assertTrue("g15_fgm_BX_1_512" in mag_vars)
+        self.assertTrue("g15_fgm_BY_1_512" in mag_vars)
+        self.assertTrue("g15_fgm_BZ_1_512" in mag_vars)
+        self.assertTrue(data_exists("g15_fgm_BX_1_512"))
+        self.assertTrue(data_exists("g15_fgm_BY_1_512"))
+        self.assertTrue(data_exists("g15_fgm_BZ_1_512"))
 
     def test_load_1min_epead_data(self):
         del_data()
         epead_vars = pyspedas.goes.epead()
-        self.assertTrue('E1E_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('E1E_UNCOR_FLUX'))
-        self.assertTrue('E1W_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('E1W_UNCOR_FLUX'))
-        self.assertTrue('E2E_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('E2E_UNCOR_FLUX'))
-        self.assertTrue('P1E_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('P1E_UNCOR_FLUX'))
-        self.assertTrue('P1W_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('P1W_UNCOR_FLUX'))
-        self.assertTrue('P2E_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('P2E_UNCOR_FLUX'))
-        self.assertTrue('A1E_FLUX' in epead_vars)
-        self.assertTrue(data_exists('A1E_FLUX'))
-        self.assertTrue('A1W_FLUX' in epead_vars)
-        self.assertTrue(data_exists('A1W_FLUX'))
-        self.assertTrue('A2E_FLUX' in epead_vars)
-        self.assertTrue(data_exists('A2E_FLUX'))
+        self.assertTrue("g15_epead_E1E_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_E1E_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_E1W_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_E1W_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_E2E_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_E2E_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_P1E_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_P1E_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_P1W_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_P1W_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_P2E_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_P2E_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_A1E_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_A1E_FLUX"))
+        self.assertTrue("g15_epead_A1W_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_A1W_FLUX"))
+        self.assertTrue("g15_epead_A2E_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_A2E_FLUX"))
 
     def test_load_full_epead_data(self):
         del_data()
-        epead_vars = pyspedas.goes.epead(datatype='1min')
-        self.assertTrue('E1E_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('E1E_UNCOR_FLUX'))
-        self.assertTrue('E1W_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('E1W_UNCOR_FLUX'))
-        self.assertTrue('E2E_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('E2E_UNCOR_FLUX'))
-        self.assertTrue('P1E_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('P1E_UNCOR_FLUX'))
-        self.assertTrue('P1W_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('P1W_UNCOR_FLUX'))
-        self.assertTrue('P2E_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('P2E_UNCOR_FLUX'))
-        self.assertTrue('A1E_FLUX' in epead_vars)
-        self.assertTrue(data_exists('A1E_FLUX'))
-        self.assertTrue('A1W_FLUX' in epead_vars)
-        self.assertTrue(data_exists('A1W_FLUX'))
-        self.assertTrue('A2E_FLUX' in epead_vars)
-        self.assertTrue(data_exists('A2E_FLUX'))
+        epead_vars = pyspedas.goes.epead(datatype="1min")
+        self.assertTrue("g15_epead_E1E_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_E1E_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_E1W_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_E1W_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_E2E_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_E2E_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_P1E_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_P1E_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_P1W_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_P1W_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_P2E_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_P2E_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_A1E_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_A1E_FLUX"))
+        self.assertTrue("g15_epead_A1W_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_A1W_FLUX"))
+        self.assertTrue("g15_epead_A2E_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_A2E_FLUX"))
 
     def test_load_5min_epead_data(self):
         del_data()
-        epead_vars = pyspedas.goes.epead(datatype='5min')
-        self.assertTrue('E1E_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('E1E_UNCOR_FLUX'))
-        self.assertTrue('E1W_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('E1W_UNCOR_FLUX'))
-        self.assertTrue('E2E_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('E2E_UNCOR_FLUX'))
-        self.assertTrue('P1E_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('P1E_UNCOR_FLUX'))
-        self.assertTrue('P1W_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('P1W_UNCOR_FLUX'))
-        self.assertTrue('P2E_UNCOR_FLUX' in epead_vars)
-        self.assertTrue(data_exists('P2E_UNCOR_FLUX'))
-        self.assertTrue('A1E_FLUX' in epead_vars)
-        self.assertTrue(data_exists('A1E_FLUX'))
-        self.assertTrue('A1W_FLUX' in epead_vars)
-        self.assertTrue(data_exists('A1W_FLUX'))
-        self.assertTrue('A2E_FLUX' in epead_vars)
-        self.assertTrue(data_exists('A2E_FLUX'))
+        epead_vars = pyspedas.goes.epead(datatype="5min")
+        self.assertTrue("g15_epead_E1E_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_E1E_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_E1W_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_E1W_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_E2E_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_E2E_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_P1E_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_P1E_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_P1W_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_P1W_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_P2E_UNCOR_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_P2E_UNCOR_FLUX"))
+        self.assertTrue("g15_epead_A1E_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_A1E_FLUX"))
+        self.assertTrue("g15_epead_A1W_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_A1W_FLUX"))
+        self.assertTrue("g15_epead_A2E_FLUX" in epead_vars)
+        self.assertTrue(data_exists("g15_epead_A2E_FLUX"))
 
     def test_load_full_maged_data(self):
         del_data()
-        maged_vars = pyspedas.goes.maged(datatype='full')
-        self.assertTrue('M_1ME1_DTC_UNCOR_CR' in maged_vars)
-        self.assertTrue(data_exists('M_1ME1_DTC_UNCOR_CR'))
-        self.assertTrue('M_1ME2_DTC_UNCOR_CR' in maged_vars)
-        self.assertTrue(data_exists('M_1ME2_DTC_UNCOR_CR'))
-        self.assertTrue('M_1ME3_DTC_UNCOR_CR' in maged_vars)
-        self.assertTrue(data_exists('M_1ME3_DTC_UNCOR_CR'))
-        self.assertTrue('M_1ME4_DTC_UNCOR_CR' in maged_vars)
-        self.assertTrue(data_exists('M_1ME4_DTC_UNCOR_CR'))
-        self.assertTrue('M_1ME5_DTC_UNCOR_CR' in maged_vars)
-        self.assertTrue(data_exists('M_1ME5_DTC_UNCOR_CR'))
+        maged_vars = pyspedas.goes.maged(datatype="full")
+        self.assertTrue("g15_maged_M_1ME1_DTC_UNCOR_CR" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_1ME1_DTC_UNCOR_CR"))
+        self.assertTrue("g15_maged_M_1ME2_DTC_UNCOR_CR" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_1ME2_DTC_UNCOR_CR"))
+        self.assertTrue("g15_maged_M_1ME3_DTC_UNCOR_CR" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_1ME3_DTC_UNCOR_CR"))
+        self.assertTrue("g15_maged_M_1ME4_DTC_UNCOR_CR" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_1ME4_DTC_UNCOR_CR"))
+        self.assertTrue("g15_maged_M_1ME5_DTC_UNCOR_CR" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_1ME5_DTC_UNCOR_CR"))
 
     def test_load_1min_maged_data(self):
         del_data()
-        maged_vars = pyspedas.goes.maged(datatype='1min', time_clip=True)
-        self.assertTrue('M_1ME1_DTC_UNCOR_FLUX' in maged_vars)
-        self.assertTrue(data_exists('M_1ME1_DTC_UNCOR_FLUX'))
-        self.assertTrue('M_1ME2_DTC_UNCOR_FLUX' in maged_vars)
-        self.assertTrue(data_exists('M_1ME2_DTC_UNCOR_FLUX'))
-        self.assertTrue('M_1ME3_DTC_UNCOR_FLUX' in maged_vars)
-        self.assertTrue(data_exists('M_1ME3_DTC_UNCOR_FLUX'))
-        self.assertTrue('M_1ME4_DTC_UNCOR_FLUX' in maged_vars)
-        self.assertTrue(data_exists('M_1ME4_DTC_UNCOR_FLUX'))
-        self.assertTrue('M_1ME5_DTC_UNCOR_FLUX' in maged_vars)
-        self.assertTrue(data_exists('M_1ME5_DTC_UNCOR_FLUX'))
+        maged_vars = pyspedas.goes.maged(datatype="1min", time_clip=True)
+        self.assertTrue("g15_maged_M_1ME1_DTC_UNCOR_FLUX" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_1ME1_DTC_UNCOR_FLUX"))
+        self.assertTrue("g15_maged_M_1ME2_DTC_UNCOR_FLUX" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_1ME2_DTC_UNCOR_FLUX"))
+        self.assertTrue("g15_maged_M_1ME3_DTC_UNCOR_FLUX" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_1ME3_DTC_UNCOR_FLUX"))
+        self.assertTrue("g15_maged_M_1ME4_DTC_UNCOR_FLUX" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_1ME4_DTC_UNCOR_FLUX"))
+        self.assertTrue("g15_maged_M_1ME5_DTC_UNCOR_FLUX" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_1ME5_DTC_UNCOR_FLUX"))
 
     def test_load_5min_maged_data(self):
         del_data()
-        maged_vars = pyspedas.goes.maged(datatype='5min', time_clip=True)
-        self.assertTrue('M_2ME1_DTC_COR_FLUX' in maged_vars)
-        self.assertTrue(data_exists('M_2ME1_DTC_COR_FLUX'))
-        self.assertTrue('M_2ME2_DTC_COR_FLUX' in maged_vars)
-        self.assertTrue(data_exists('M_2ME2_DTC_COR_FLUX'))
-        self.assertTrue('M_2ME3_DTC_COR_FLUX' in maged_vars)
-        self.assertTrue(data_exists('M_2ME3_DTC_COR_FLUX'))
-        self.assertTrue('M_2ME4_DTC_COR_FLUX' in maged_vars)
-        self.assertTrue(data_exists('M_2ME4_DTC_COR_FLUX'))
-        self.assertTrue('M_2ME5_DTC_COR_FLUX' in maged_vars)
-        self.assertTrue(data_exists('M_2ME5_DTC_COR_FLUX'))
+        maged_vars = pyspedas.goes.maged(datatype="5min", time_clip=True)
+        self.assertTrue("g15_maged_M_2ME1_DTC_COR_FLUX" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_2ME1_DTC_COR_FLUX"))
+        self.assertTrue("g15_maged_M_2ME2_DTC_COR_FLUX" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_2ME2_DTC_COR_FLUX"))
+        self.assertTrue("g15_maged_M_2ME3_DTC_COR_FLUX" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_2ME3_DTC_COR_FLUX"))
+        self.assertTrue("g15_maged_M_2ME4_DTC_COR_FLUX" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_2ME4_DTC_COR_FLUX"))
+        self.assertTrue("g15_maged_M_2ME5_DTC_COR_FLUX" in maged_vars)
+        self.assertTrue(data_exists("g15_maged_M_2ME5_DTC_COR_FLUX"))
 
     def test_load_full_magpd_data(self):
         del_data()
-        magpd_vars = pyspedas.goes.magpd(datatype='full')
-        self.assertTrue('M_1MP1_DTC_UNCOR_CR' in magpd_vars)
-        self.assertTrue(data_exists('M_1MP1_DTC_UNCOR_CR'))
-        self.assertTrue('M_1MP2_DTC_UNCOR_CR' in magpd_vars)
-        self.assertTrue(data_exists('M_1MP2_DTC_UNCOR_CR'))
-        self.assertTrue('M_1MP3_DTC_UNCOR_CR' in magpd_vars)
-        self.assertTrue(data_exists('M_1MP3_DTC_UNCOR_CR'))
-        self.assertTrue('M_1MP4_DTC_UNCOR_CR' in magpd_vars)
-        self.assertTrue(data_exists('M_1MP4_DTC_UNCOR_CR'))
-        self.assertTrue('M_1MP5_DTC_UNCOR_CR' in magpd_vars)
-        self.assertTrue(data_exists('M_1MP5_DTC_UNCOR_CR'))
+        magpd_vars = pyspedas.goes.magpd(datatype="full")
+        self.assertTrue("g15_magpd_M_1MP1_DTC_UNCOR_CR" in magpd_vars)
+        self.assertTrue(data_exists("g15_magpd_M_1MP1_DTC_UNCOR_CR"))
+        self.assertTrue("g15_magpd_M_1MP2_DTC_UNCOR_CR" in magpd_vars)
+        self.assertTrue(data_exists("g15_magpd_M_1MP2_DTC_UNCOR_CR"))
+        self.assertTrue("g15_magpd_M_1MP3_DTC_UNCOR_CR" in magpd_vars)
+        self.assertTrue(data_exists("g15_magpd_M_1MP3_DTC_UNCOR_CR"))
+        self.assertTrue("g15_magpd_M_1MP4_DTC_UNCOR_CR" in magpd_vars)
+        self.assertTrue(data_exists("g15_magpd_M_1MP4_DTC_UNCOR_CR"))
+        self.assertTrue("g15_magpd_M_1MP5_DTC_UNCOR_CR" in magpd_vars)
+        self.assertTrue(data_exists("g15_magpd_M_1MP5_DTC_UNCOR_CR"))
 
     def test_load_1min_magpd_data(self):
         del_data()
-        magpd_vars = pyspedas.goes.magpd(datatype='1min', time_clip=True)
-        self.assertTrue('M_1MP1_DTC_UNCOR_FLUX' in magpd_vars)
-        self.assertTrue(data_exists('M_1MP1_DTC_UNCOR_FLUX'))
-        self.assertTrue('M_1MP2_DTC_UNCOR_FLUX' in magpd_vars)
-        self.assertTrue(data_exists('M_1MP2_DTC_UNCOR_FLUX'))
-        self.assertTrue('M_1MP3_DTC_UNCOR_FLUX' in magpd_vars)
-        self.assertTrue(data_exists('M_1MP3_DTC_UNCOR_FLUX'))
-        self.assertTrue('M_1MP4_DTC_UNCOR_FLUX' in magpd_vars)
-        self.assertTrue(data_exists('M_1MP4_DTC_UNCOR_FLUX'))
-        self.assertTrue('M_1MP5_DTC_UNCOR_FLUX' in magpd_vars)
-        self.assertTrue(data_exists('M_1MP5_DTC_UNCOR_FLUX'))
+        magpd_vars = pyspedas.goes.magpd(datatype="1min", time_clip=True)
+        self.assertTrue("g15_magpd_M_1MP1_DTC_UNCOR_FLUX" in magpd_vars)
+        self.assertTrue(data_exists("g15_magpd_M_1MP1_DTC_UNCOR_FLUX"))
+        self.assertTrue("g15_magpd_M_1MP2_DTC_UNCOR_FLUX" in magpd_vars)
+        self.assertTrue(data_exists("g15_magpd_M_1MP2_DTC_UNCOR_FLUX"))
+        self.assertTrue("g15_magpd_M_1MP3_DTC_UNCOR_FLUX" in magpd_vars)
+        self.assertTrue(data_exists("g15_magpd_M_1MP3_DTC_UNCOR_FLUX"))
+        self.assertTrue("g15_magpd_M_1MP4_DTC_UNCOR_FLUX" in magpd_vars)
+        self.assertTrue(data_exists("g15_magpd_M_1MP4_DTC_UNCOR_FLUX"))
+        self.assertTrue("g15_magpd_M_1MP5_DTC_UNCOR_FLUX" in magpd_vars)
+        self.assertTrue(data_exists("g15_magpd_M_1MP5_DTC_UNCOR_FLUX"))
 
     def test_load_full_hepad_data(self):
         del_data()
-        hepad_vars = pyspedas.goes.hepad(datatype='full')
-        self.assertTrue('P10_FLUX' in hepad_vars)
-        self.assertTrue('S1_COUNT_RATE'in hepad_vars)
-        self.assertTrue(data_exists('P10_FLUX'))
-        self.assertTrue(data_exists('S1_COUNT_RATE'))
+        hepad_vars = pyspedas.goes.hepad(datatype="full")
+        self.assertTrue("g15_hepad_P10_FLUX" in hepad_vars)
+        self.assertTrue("g15_hepad_S1_COUNT_RATE" in hepad_vars)
+        self.assertTrue(data_exists("g15_hepad_P10_FLUX"))
+        self.assertTrue(data_exists("g15_hepad_S1_COUNT_RATE"))
 
     def test_load_1min_hepad_data(self):
         del_data()
-        hepad_vars = pyspedas.goes.hepad(prefix='probename', time_clip=True)
-        self.assertTrue('g15_P10_FLUX' in hepad_vars)
-        self.assertTrue('g15_S1_COUNT_RATE' in hepad_vars)
-        self.assertTrue(data_exists('g15_P10_FLUX'))
-        self.assertTrue(data_exists('g15_S1_COUNT_RATE'))
+        hepad_vars = pyspedas.goes.hepad(prefix="probename", time_clip=True)
+        self.assertTrue("g15_hepad_P10_FLUX" in hepad_vars)
+        self.assertTrue("g15_hepad_S1_COUNT_RATE" in hepad_vars)
+        self.assertTrue(data_exists("g15_hepad_P10_FLUX"))
+        self.assertTrue(data_exists("g15_hepad_S1_COUNT_RATE"))
 
     def test_load_xrs_data(self):
         del_data()
-        xrs_vars = pyspedas.goes.xrs(probe='10', datatype='full', trange=['2002-08-01', '2002-08-01'])
-        self.assertTrue('xl' in xrs_vars)
-        self.assertTrue(data_exists('xl'))
+        xrs_vars = pyspedas.goes.xrs(
+            probe="10", datatype="full", trange=["2002-08-01", "2002-08-01"]
+        )
+        self.assertTrue("g10_xrs_xl" in xrs_vars)
+        self.assertTrue(data_exists("g10_xrs_xl"))
 
     def test_load_xrs_5m_data(self):
         del_data()
-        xrs_vars = pyspedas.goes.xrs(probe='11', datatype='5min', trange=['2000-09-01', '2000-09-01'], time_clip=True)
-        self.assertTrue('xl' in xrs_vars)
-        self.assertTrue(data_exists('xl'))
+        xrs_vars = pyspedas.goes.xrs(
+            probe="11",
+            datatype="5min",
+            trange=["2000-09-01", "2000-09-01"],
+            time_clip=True,
+        )
+        self.assertTrue("g11_xrs_xl" in xrs_vars)
+        self.assertTrue(data_exists("g11_xrs_xl"))
 
     def test_load_xrs_1m_data(self):
         del_data()
-        xrs_vars = pyspedas.goes.xrs(probe='11', datatype='1min', trange=['2000-09-01', '2000-09-01'], prefix='probename', time_clip=True)
-        self.assertTrue('g11_xs' in xrs_vars)
-        self.assertTrue(data_exists('g11_xs'))
+        xrs_vars = pyspedas.goes.xrs(
+            probe="11",
+            datatype="1min",
+            trange=["2000-09-01", "2000-09-01"],
+            prefix="probename",
+            time_clip=True,
+        )
+        self.assertTrue("g11_xrs_xs" in xrs_vars)
+        self.assertTrue(data_exists("g11_xrs_xs"))
 
     def test_load_eps_1m_data(self):
         del_data()
-        eps_vars = pyspedas.goes.eps(trange=['2000-09-01', '2000-09-01'], probe='11', time_clip=True)
-        self.assertTrue('e1_flux_i' in eps_vars)
-        self.assertTrue('e2_flux_i' in eps_vars)
-        self.assertTrue('e3_flux_i' in eps_vars)
-        self.assertTrue(data_exists('e1_flux_i'))
-        self.assertTrue(data_exists('e2_flux_i'))
-        self.assertTrue(data_exists('e3_flux_i'))
+        eps_vars = pyspedas.goes.eps(
+            trange=["2000-09-01", "2000-09-01"], probe="11", time_clip=True
+        )
+        self.assertTrue("g11_eps_e1_flux_i" in eps_vars)
+        self.assertTrue("g11_eps_e2_flux_i" in eps_vars)
+        self.assertTrue("g11_eps_e3_flux_i" in eps_vars)
+        self.assertTrue(data_exists("g11_eps_e1_flux_i"))
+        self.assertTrue(data_exists("g11_eps_e2_flux_i"))
+        self.assertTrue(data_exists("g11_eps_e3_flux_i"))
 
     def test_load_eps_5m_data(self):
         del_data()
-        eps_vars = pyspedas.goes.eps(trange=['2000-09-01', '2000-09-01'], probe='11', datatype='5min', time_clip=True)
-        self.assertTrue('p1_flux' in eps_vars)
-        self.assertTrue('p2_flux' in eps_vars)
-        self.assertTrue('p3_flux' in eps_vars)
-        self.assertTrue('p4_flux' in eps_vars)
-        self.assertTrue('p5_flux' in eps_vars)
-        self.assertTrue('p6_flux' in eps_vars)
-        self.assertTrue('p7_flux' in eps_vars)
-        self.assertTrue(data_exists('p1_flux'))
-        self.assertTrue(data_exists('p2_flux'))
-        self.assertTrue(data_exists('p3_flux'))
-        self.assertTrue(data_exists('p4_flux'))
-        self.assertTrue(data_exists('p5_flux'))
-        self.assertTrue(data_exists('p6_flux'))
-        self.assertTrue(data_exists('p7_flux'))
+        eps_vars = pyspedas.goes.eps(
+            trange=["2000-09-01", "2000-09-01"],
+            probe="11",
+            datatype="5min",
+            time_clip=True,
+        )
+        self.assertTrue("g11_eps_p1_flux" in eps_vars)
+        self.assertTrue("g11_eps_p2_flux" in eps_vars)
+        self.assertTrue("g11_eps_p3_flux" in eps_vars)
+        self.assertTrue("g11_eps_p4_flux" in eps_vars)
+        self.assertTrue("g11_eps_p5_flux" in eps_vars)
+        self.assertTrue("g11_eps_p6_flux" in eps_vars)
+        self.assertTrue("g11_eps_p7_flux" in eps_vars)
+        self.assertTrue(data_exists("g11_eps_p1_flux"))
+        self.assertTrue(data_exists("g11_eps_p2_flux"))
+        self.assertTrue(data_exists("g11_eps_p3_flux"))
+        self.assertTrue(data_exists("g11_eps_p4_flux"))
+        self.assertTrue(data_exists("g11_eps_p5_flux"))
+        self.assertTrue(data_exists("g11_eps_p6_flux"))
+        self.assertTrue(data_exists("g11_eps_p7_flux"))
 
     def test_load_xrs_data_16(self):
         del_data()
-        xrs_vars_16 = pyspedas.goes.xrs(probe='16', trange=['2022-09-01', '2022-09-02'])
-        self.assertTrue('xrsa_flux' in xrs_vars_16)
-        self.assertTrue(data_exists('xrsa_flux'))
+        xrs_vars_16 = pyspedas.goes.xrs(probe="16", trange=["2022-09-01", "2022-09-02"])
+        self.assertTrue("g16_xrs_xrsa_flux" in xrs_vars_16)
+        self.assertTrue(data_exists("g16_xrs_xrsa_flux"))
 
     def test_load_xrs_data_17_hi(self):
         del_data()
-        xrs_vars_17 = pyspedas.goes.xrs(probe='17', trange=['2022-07-01', '2022-07-02'], datatype='hi')
-        self.assertTrue('xrsb_flux' in xrs_vars_17)
-        self.assertTrue(data_exists('xrsb_flux'))
+        xrs_vars_17 = pyspedas.goes.xrs(
+            probe="17", trange=["2022-07-01", "2022-07-02"], datatype="hi"
+        )
+        self.assertTrue("g17_xrs_xrsb_flux" in xrs_vars_17)
+        self.assertTrue(data_exists("g17_xrs_xrsb_flux"))
 
     def test_load_euvs_data_17(self):
         del_data()
-        euvs_vars_17 = pyspedas.goes.euvs(probe='17', trange=['2022-09-01', '2022-09-02'], prefix='probename')
-        self.assertTrue('g17_irr_256' in euvs_vars_17)
-        self.assertTrue(data_exists('g17_irr_256'))
+        euvs_vars_17 = pyspedas.goes.euvs(
+            probe="17", trange=["2022-09-01", "2022-09-02"]
+        )
+        self.assertTrue("g17_euvs_irr_256" in euvs_vars_17)
+        self.assertTrue(data_exists("g17_euvs_irr_256"))
 
     def test_load_euvs_data_16_hi(self):
         del_data()
-        euvs_vars_16 = pyspedas.goes.euvs(probe='16', trange=['2022-08-01', '2022-08-02'], prefix='probename', datatype='hi')
-        self.assertTrue('g16_irr_256' in euvs_vars_16)
-        self.assertTrue(data_exists('g16_irr_256'))
+        euvs_vars_16 = pyspedas.goes.euvs(
+            probe="16",
+            trange=["2022-08-01", "2022-08-02"],
+            prefix="probename",
+            datatype="hi",
+        )
+        self.assertTrue("g16_euvs_irr_256" in euvs_vars_16)
+        self.assertTrue(data_exists("g16_euvs_irr_256"))
 
     def test_load_mag_data_16(self):
         del_data()
-        mag_vars_16 = pyspedas.goes.mag(probe='16', trange=['2023-01-30', '2023-01-31'], prefix='goes16_')
-        self.assertTrue('goes16_b_total' in mag_vars_16)
-        self.assertTrue(data_exists('goes16_b_total'))
+        mag_vars_16 = pyspedas.goes.mag(
+            probe="16", trange=["2023-01-30", "2023-01-31"], prefix="goes16_"
+        )
+        self.assertTrue("goes16_b_total" in mag_vars_16)
+        self.assertTrue(data_exists("goes16_b_total"))
 
     def test_load_mag_data_17(self):
         del_data()
-        mag_vars_17 = pyspedas.goes.mag(probe='17', trange=['2022-01-30', '2022-01-31'], prefix='goes17_', datatype='hi')
-        self.assertTrue('goes17_b_gse' in mag_vars_17)
-        self.assertTrue(data_exists('goes17_b_gse'))
+        mag_vars_17 = pyspedas.goes.mag(
+            probe="17",
+            trange=["2022-01-30", "2022-01-31"],
+            prefix="goes17_",
+            datatype="hi",
+        )
+        self.assertTrue("goes17_b_gse" in mag_vars_17)
+        self.assertTrue(data_exists("goes17_b_gse"))
 
     def test_load_mpsh_data_17(self):
         del_data()
-        mpsh_vars_17 = pyspedas.goes.mpsh(probe='17', trange=['2022-09-01', '2022-09-02'], prefix='probename', time_clip=True)
-        self.assertTrue('g17_AvgDiffElectronFlux' in mpsh_vars_17)
-        self.assertTrue(data_exists('g17_AvgDiffElectronFlux'))
+        mpsh_vars_17 = pyspedas.goes.mpsh(
+            probe="17",
+            trange=["2022-09-01", "2022-09-02"],
+            prefix="probename",
+            time_clip=True,
+        )
+        self.assertTrue("g17_mpsh_AvgDiffElectronFlux" in mpsh_vars_17)
+        self.assertTrue(data_exists("g17_mpsh_AvgDiffElectronFlux"))
 
     def test_load_mpsh_data_16(self):
         del_data()
-        mpsh_vars_16 = pyspedas.goes.mpsh(probe='16', trange=['2022-10-01', '2022-10-02'], prefix='probename', datatype='hi')
-        self.assertTrue('g16_AvgDiffProtonFlux' in mpsh_vars_16)
-        self.assertTrue(data_exists('g16_AvgDiffProtonFlux'))
+        mpsh_vars_16 = pyspedas.goes.mpsh(
+            probe="16", trange=["2022-10-01", "2022-10-02"], prefix="", datatype="hi"
+        )
+        self.assertTrue("g16_mpsh_AvgDiffProtonFlux" in mpsh_vars_16)
+        self.assertTrue(data_exists("g16_mpsh_AvgDiffProtonFlux"))
 
     def test_load_sgps_data_16(self):
         del_data()
-        sgps_vars_16 = pyspedas.goes.sgps(probe='16', trange=['2023-01-30', '2023-01-31'], prefix='probename')
-        self.assertTrue('g16_AvgDiffAlphaFlux' in sgps_vars_16)
-        self.assertTrue(data_exists('g16_AvgDiffAlphaFlux'))
+        sgps_vars_16 = pyspedas.goes.sgps(
+            probe="16", trange=["2023-01-30", "2023-01-31"], prefix="probename"
+        )
+        self.assertTrue("g16_sgps_AvgDiffAlphaFlux" in sgps_vars_16)
+        self.assertTrue(data_exists("g16_sgps_AvgDiffAlphaFlux"))
 
     def test_load_sgps_data_18(self):
         del_data()
-        sgps_vars_18 = pyspedas.goes.sgps(probe='18', trange=['2023-01-30', '2023-01-31'], prefix='probename', datatype='hi', time_clip=True)
-        self.assertTrue('g18_AvgIntProtonFlux' in sgps_vars_18)
-        self.assertTrue(data_exists('g18_AvgIntProtonFlux'))
+        sgps_vars_18 = pyspedas.goes.sgps(
+            probe="18",
+            trange=["2023-01-30", "2023-01-31"],
+            datatype="hi",
+            time_clip=True,
+        )
+        self.assertTrue("g18_sgps_AvgIntProtonFlux" in sgps_vars_18)
+        self.assertTrue(data_exists("g18_sgps_AvgIntProtonFlux"))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Now the default variable prefixes include both the GOES probe number and the instrument, for example "g16_mag_". This solves of problem of overwriting variables that have the same name for different instruments (for example, AvgDiffProtonFlux for both SGPS and MPSH). Also made a few secondary changes to docstrings, added examples, added the ability to provide multiple instruments , made time_clip=True the default.