### PR TITLE
Plot Wind/WAVES RAD1 and RAD2 data

### DIFF
--- a/pyspedas/projects/wind/load.py
+++ b/pyspedas/projects/wind/load.py
@@ -59,7 +59,7 @@ def load(trange=['2013-11-5', '2013-11-6'],
         masterfile = 'wi_' + datatype + '_sms_00000000_v01.cdf'
     elif instrument == 'waves':
         if datatype == 'rad1' or datatype == 'rad2':
-            prefix = user_prefix + 'wi_' + datatype + '_'
+            prefix = user_prefix + 'wi_l2_wav_' + datatype + '_'
             pathformat = 'waves/'+datatype+'_l2/%Y/wi_l2_wav_'+datatype+'_%Y%m%d_v??.cdf'
             masterfile = 'wi_l2_wav_'+datatype+'_00000000_v01.cdf'
         else:


### PR DESCRIPTION
Wind/WAVES Level 2 RAD1 and RAD2 data have a different naming scheme than the other Wind/WAVES data products.

Example code to load and plot:

```
import pyspedas
from pytplot import tplot, tplot_names

# example of a Type III radio burst

trange = ['2019-04-02/15:00', '2019-04-02/16:30']

pyspedas.wind.waves(trange=trange, time_clip=True, datatype='rad2')
pyspedas.wind.waves(trange=trange, time_clip=True, datatype='rad1')

tplot_names()

tplot('wi_l2_wav_rad?_PSD_V2_Z')
```