### PR TITLE
Testing Bulk Velocity Shift for mms_get_spec

### DIFF
--- a/pyspedas/__init__.py
+++ b/pyspedas/__init__.py
@@ -39,7 +39,7 @@ from .cotrans_tools.xyz_to_polar import xyz_to_polar
 from .hapi_tools.hapi import hapi
 
 from .particles.moments import moments_3d, spd_pgs_moments, spd_pgs_moments_tplot
-from .particles.spd_part_products import spd_pgs_do_fac, spd_pgs_regrid
+from .particles.spd_part_products import spd_pgs_do_fac, spd_pgs_regrid, spd_pgs_v_shift
 from .particles.spd_slice2d import slice1d_plot, slice2d, slice2d_plot
 from .utilities.spice.time_ephemeris import time_ephemeris
 from .utilities.dailynames import dailynames

--- a/pyspedas/particles/spd_part_products/__init__.py
+++ b/pyspedas/particles/spd_part_products/__init__.py
@@ -1,2 +1,3 @@
 from .spd_pgs_do_fac import spd_pgs_do_fac
 from .spd_pgs_regrid import spd_pgs_regrid
+from .spd_pgs_v_shift import spd_pgs_v_shift

--- a/pyspedas/particles/spd_part_products/spd_pgs_v_shift.py
+++ b/pyspedas/particles/spd_part_products/spd_pgs_v_shift.py
@@ -49,5 +49,3 @@ def spd_pgs_v_shift(data, vector):
     data['energy'] = .5 * data['mass'] * v_new**2
     data['theta'] = theta
     data['phi'] = phi
-
-    print("spd_pgs_v_shift.py has been loaded")

--- a/pyspedas/particles/spd_part_products/spd_pgs_v_shift.py
+++ b/pyspedas/particles/spd_part_products/spd_pgs_v_shift.py
@@ -1,0 +1,53 @@
+import numpy as np
+from pyspedas.cotrans_tools.cart2spc import cart2spc
+from pyspedas.cotrans_tools.spc2cart import spc2cart
+
+def spd_pgs_v_shift(data, vector):
+# Procedure:
+# spd_pgs_v_shift
+# 
+# Purpose:
+#   Shift a single distribution strucure by a specified velocity vector
+# 
+# Input:
+#   data:  Sanitized particle data structure to be operated on
+#   vector:  3-vector in km/s
+#   matrix:  (optional) rotation matrix to apply to vector before shift
+# 
+# Output:
+#   error:  flag, 1 indicates error, 0 none
+# 
+# Notes:
+#   -Particle velocities are assumed to be small enough 
+#    to use classical calculation.
+# 
+
+# Ensure vector has exactly 3 elements
+    if len(vector) != 3:
+        return
+
+# If matrix has 9 elements, do matrix-vector multiplication
+    #if matrix.size == 9:
+        #vector = matrix.reshape(3, 3) @ vector
+
+    # calculate bin velocities
+    # distribution mass in eV/(km/s)^2
+    v = np.sqrt(2.0 * data['energy']/data['mass'])
+    theta = data['theta']
+    phi = data['phi']
+
+    #sphere to cart
+    x, y, z = spc2cart(v, theta, phi)
+
+    #subtract input vector
+    newx = x - vector[0]
+    newy = y - vector[1]
+    newz = z - vector[2]    
+
+    #cart to sphere
+    v_new, theta, phi = cart2spc(newx, newy, newz)
+    data['energy'] = .5 * data['mass'] * v_new**2
+    data['theta'] = theta
+    data['phi'] = phi
+
+    print("spd_pgs_v_shift.py has been loaded")


### PR DESCRIPTION
added spd_pgs_v_shift and tried to copy the same structure as the IDL routine. the spectrograms are the same if the bulk-velocity isn't subtracted. When subtract_bulk = true, a spectrogram is made, but differs from the IDL spectrogram by a few orders of magnitude. The overall shape of the distribution is retained though. 