### PR TITLE
Fix issue #1183: cannot handle 'string' type in HAPI

### DIFF
--- a/pyspedas/hapi_tools/hapi.py
+++ b/pyspedas/hapi_tools/hapi.py
@@ -143,10 +143,14 @@ def hapi(trange=None, server=None, dataset=None, parameters='', suffix='',
                 continue
 
         for idx, datapoint in enumerate(data):
-            if single_line:
-                data_out[idx] = datapoint[param_idx+1]
+            if param_type in ['double','integer']:
+                datapt = datapoint[param_idx+1]
             else:
-                data_out[idx, :] = datapoint[param_idx+1]
+                datapt = None
+            if single_line:
+                data_out[idx] = datapt
+            else:
+                data_out[idx, :] = datapt
 
         data_out = data_out.squeeze()
 


### PR DESCRIPTION
Currently pyspedas.hapi cannot handle 'string' type in HAPI as data is stored in a numpy array.
Fix sets strings to None, so although string data is lost, at least it is not breaking.