### PR TITLE
fixed tnames searching for EIS omni-directional spin/averaging 

### DIFF
--- a/pyspedas/projects/mms/eis_tools/mms_eis_omni.py
+++ b/pyspedas/projects/mms/eis_tools/mms_eis_omni.py
@@ -40,7 +40,7 @@ def mms_eis_omni(probe, species='proton', datatype='extof', suffix='', data_unit
     
     probe = str(probe)
     species_str = datatype + '_' + species
-    prefix = 'mms' + probe + '_epd_eis_' + data_rate + '_' + level + '_'
+    prefix = 'mms' + probe + '_epd_eis_' + data_rate + '_' 
 
     if data_units == 'flux':
         units_label = '1/(cm^2-sr-s-keV)'
@@ -49,8 +49,8 @@ def mms_eis_omni(probe, species='proton', datatype='extof', suffix='', data_unit
     elif data_units == 'counts':
         units_label = 'counts'
 
-    telescopes = tnames(pattern=prefix + species_str + '_*' + data_units + '_t?'+suffix)
-
+    #telescopes = tnames(pattern=prefix + level + '_' + species_str + '_*_' + data_units + '_t?' + suffix)
+    telescopes = tnames([f'{prefix}{level}_{datatype}_{species}_P*_{data_units}_t?{suffix}', f'{prefix}{datatype}_{species}_P*_{data_units}_t?{suffix}'])
     if len(telescopes) == 6:
         scope_data = get_data(telescopes[0])
             

--- a/pyspedas/projects/mms/eis_tools/mms_eis_spin_avg.py
+++ b/pyspedas/projects/mms/eis_tools/mms_eis_spin_avg.py
@@ -47,7 +47,7 @@ def mms_eis_spin_avg(probe='1', species='proton', data_units='flux', datatype='e
     --------
         List of tplot variables created.
     """
-    prefix = 'mms' + probe + '_epd_eis_' + data_rate + '_' + level + '_'
+    prefix = 'mms' + probe + '_epd_eis_' + data_rate + '_' 
 
     if data_units == 'flux':
         units_label = '1/(cm^2-sr-s-keV)'
@@ -58,8 +58,10 @@ def mms_eis_spin_avg(probe='1', species='proton', data_units='flux', datatype='e
 
     spin_data = get_data(prefix + datatype + '_spin' + suffix)
     if spin_data is None:
-        logging.error('Error, problem finding EIS spin variable to calculate spin-averages')
-        return
+        spin_data = get_data(prefix + '_' +  level + '_' +  datatype + '_spin' + suffix)
+        if spin_data is None:
+            logging.error('Error, problem finding EIS spin variable to calculate spin-averages')
+            return
 
     spin_times, spin_nums = spin_data
 

--- a/pyspedas/projects/mms/particles/mms_part_getspec.py
+++ b/pyspedas/projects/mms/particles/mms_part_getspec.py
@@ -174,13 +174,13 @@ def mms_part_getspec(instrument='fpi',
     if trange is None:
         logging.error('Time range not specified; please specify time range using the trange keyword.')
         return
-### new ####
+
     if vel_data_rate is None:  # type: ignore
         if data_rate == 'brst':
             vel_data_rate = 'brst'
         else:
             vel_data_rate = 'srvy'
-####### new #########
+
     if mag_data_rate is None:
         if data_rate == 'brst':
             mag_data_rate = 'brst'

--- a/pyspedas/projects/mms/particles/mms_part_products.py
+++ b/pyspedas/projects/mms/particles/mms_part_products.py
@@ -147,7 +147,7 @@ def mms_part_products(in_tvarname,
         no_regrid: bool
             Flag to disable reegridding
         
-            ###new###
+            
         subtract_bulk: bool
             Subtracts the bulk velocity from the distribution data
 
@@ -405,7 +405,6 @@ are the scientific products that should be used for analysis."""
             clean_data = mms_pgs_split_hpca(clean_data)
         
         if subtract_bulk == True: 
-            #import spd_pgs_v_shift, make sure its in correct folder
             spd_pgs_v_shift(clean_data,vel_data[i,:])
 
         # Apply phi, theta, & energy limits


### PR DESCRIPTION
Tnames would fail to find tplot variables because of the different naming conventions. Fixed the searching to include most of the possible name variations for regular averaging and spin averaging. 