### PR TITLE
Delete .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,0 @@
-[MESSAGES CONTROL]
-disable=C0301
-
-[MASTER]
-max-line-length=150


### PR DESCRIPTION
Not needed anymore. Pylint settings are inside pyproject.toml