### PR TITLE
change last_version default for loading FIELDS data

### DIFF
--- a/pyspedas/projects/psp/fields.py
+++ b/pyspedas/projects/psp/fields.py
@@ -20,7 +20,7 @@ def fields(trange=['2018-11-5', '2018-11-6'],
         time_clip=False,
         username=None,
         password=None,
-        last_version=False,
+        last_version=True,
         force_download=False,
         ):
     """


### PR DESCRIPTION
FIELDS produces initial "v00" versions of some files, where version 0 signifies that the file is a preliminary file, useful for initial analysis but without final calibrations applied. An example directory with v00 files is here:

https://research.ssl.berkeley.edu/data/spp/data/sci/fields/l2/mag_RTN_4_Sa_per_Cyc/2025/01/

With the last_version keyword set to False, both versions are downloaded, which results in multiple, overlapping versions of the same data loaded into a tplot variable (example code below).

```
import pyspedas.projects.psp as psp
from pyspedas import tnames, tplot, options, get_data
from os import environ

trange=['2025-01-01/12:00:00','2025-01-01/13:00:00']

psp.fields(trange=trange,
           datatype='mag_RTN_4_Sa_per_Cyc',
           time_clip=True,
           username = 'none', 
           password = 'none')

print(tnames())

tplot('psp_fld_l2_mag_RTN_4_Sa_per_Cyc')
```

The majority of FIELDS data users will want to use the latest data only, so this keyword should default to True for FIELDS data. 