### PR TITLE
set proper legend_names in pyspedas.split_vec()

### DIFF
--- a/pyspedas/utilities/tests/test_utilities_misc.py
+++ b/pyspedas/utilities/tests/test_utilities_misc.py
@@ -370,6 +370,10 @@ class UtilTestCases(unittest.TestCase):
         self.assertTrue(data_exists('thc_fgs_dsl_z'))
         md_x = get_data('thc_fgs_dsl_x', metadata=True)
         self.assertTrue(md_x['plot_options']['xaxis_opt']['axis_label'] == md['plot_options']['xaxis_opt']['axis_label'])
+        self.assertTrue(md_x['plot_options']['yaxis_opt']['legend_names'] == md['CDF']['LABELS'][0:1])
+        md_y = get_data('thc_fgs_dsl_y', metadata=True)
+        self.assertTrue(md_y['plot_options']['xaxis_opt']['axis_label'] == md['plot_options']['xaxis_opt']['axis_label'])
+        self.assertTrue(md_y['plot_options']['yaxis_opt']['legend_names'] == md['CDF']['LABELS'][1:2])
 
     def test_imports(self):
         import pyspedas


### PR DESCRIPTION
Fixes #1278.

`split_vec` just completely reused the metadata for the newly added split datasets, which means that all components will have the same `legend_names` list and hence only the first component will display the correct legend name.

It's actually slightly more complicated than that in that there may not be `legend_names` at all in the original vector dataset -- in this case, `metadata['CDF']['LABELS']` is used (if it exists), but that has the same problem, it's still the original list of labels rather than the one appropriate for a given component.

This PR fixes the issue by explicitly setting `legend_names` correctly for the split component -- I chose not to touch the original `metadata['CDF']['LABELS']` but add the proper `['legend_names']` attribute, which takes preference and thus fixes the legend labels.