### PR TITLE
Add initial pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,26 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
   - id: fix-spaces
   - id: fix-ligatures
   - id: forbid-bidi-controls
+
+#- repo: https://github.com/sphinx-contrib/sphinx-lint
+#  rev: v1.0.1
+#  hooks:
+#  - id: sphinx-lint
+
+- repo: https://github.com/abravalheri/validate-pyproject
+  rev: v0.24.1
+  hooks:
+  - id: validate-pyproject
+    name: validate pyproject.toml
+    additional_dependencies: ['validate-pyproject-schema-store[all]']
+
+# - repo: https://github.com/hukkin/mdformat
+#   rev: 1.0.0
+#   hooks:
+#   - id: mdformat
+#     name: format .md files
+#     additional_dependencies:
+#     - mdformat-footnote
+#     - mdformat-gfm
+#     - mdformat-gfm-alerts
+#     - mdformat-ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# configuration file for pre-commit and pre-commit.ci
+
+repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v6.0.0
+  hooks:
+  - id: check-ast
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-merge-conflict
+  - id: check-case-conflict
+  - id: check-illegal-windows-names
+  - id: name-tests-test
+  - id: detect-private-key
+  - id: fix-byte-order-marker
+  - id: mixed-line-ending
+  - id: forbid-submodules
+  - id: check-json
+  - id: check-toml
+  - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,15 +6,15 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
   rev: v6.0.0
   hooks:
   - id: check-ast
-  - id: trailing-whitespace
-  - id: end-of-file-fixer
+#  - id: trailing-whitespace
+#  - id: end-of-file-fixer
   - id: check-merge-conflict
   - id: check-case-conflict
   - id: check-illegal-windows-names
-  - id: name-tests-test
+#  - id: name-tests-test
   - id: detect-private-key
   - id: fix-byte-order-marker
-  - id: mixed-line-ending
+#  - id: mixed-line-ending
   - id: forbid-submodules
   - id: check-json
   - id: check-toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,12 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
     name: validate pyproject.toml
     additional_dependencies: ['validate-pyproject-schema-store[all]']
 
+# - repo: https://github.com/tox-dev/pyproject-fmt
+#   rev: v2.11.1
+#   hooks:
+#   - id: pyproject-fmt
+#     name: format pyproject.toml
+
 # - repo: https://github.com/hukkin/mdformat
 #   rev: 1.0.0
 #   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,12 +52,14 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 #  hooks:
 #  - id: sphinx-lint
 
-#- repo: https://github.com/codespell-project/codespell
-#  rev: v2.4.1
-#  hooks:
-#  - id: codespell
-#    name: codespell (add false positives to pyproject.toml)
-#    args: [--write-changes]
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.4.1
+  hooks:
+  - id: codespell
+    name: codespell (add false positives to pyproject.toml)
+    # temporarily exclude most files since suggested changes require some thought
+    exclude: pyspedas|docs/source
+    # args: [--write-changes]
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.35.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,12 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 #  - id: end-of-file-fixer
 #  - id: name-tests-test
 
-#- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-#  rev: v2.15.0
-#  hooks:
-#  - id: pretty-format-yaml
-#    args: [--autofix]
+- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+  rev: v2.15.0
+  hooks:
+  - id: pretty-format-yaml
+    args: [--autofix]
+    files: .pre-commit-config.yaml
 #  - id: pretty-format-ini
 #    args: [--autofix]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,8 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
   - id: detect-private-key
   - id: fix-byte-order-marker
   - id: mixed-line-ending
+    args: [--fix=lf]
+    exclude: docs/make.bat
   - id: forbid-submodules
   - id: check-toml
   - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,14 @@
 
 repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 
+#- repo: https://github.com/astral-sh/ruff-pre-commit
+#  rev: v0.14.5
+#  hooks:
+#  - id: ruff-check
+#    name: ruff-check (see https://docs.astral.sh/ruff/rules)
+#    args: [--fix]
+#  - id: ruff-format
+
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,15 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
   - id: check-merge-conflict
   - id: check-case-conflict
   - id: check-illegal-windows-names
-#  - id: name-tests-test
   - id: detect-private-key
   - id: fix-byte-order-marker
   - id: mixed-line-ending
   - id: forbid-submodules
   - id: check-toml
   - id: check-yaml
+#  - id: trailing-whitespace
+#  - id: end-of-file-fixer
+#  - id: name-tests-test
 
 #- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
 #  rev: v2.15.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,14 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
   - id: check-toml
   - id: check-yaml
 
+#- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+#  rev: v2.15.0
+#  hooks:
+#  - id: pretty-format-yaml
+#    args: [--autofix]
+#  - id: pretty-format-ini
+#    args: [--autofix]
+
 - repo: https://github.com/sirosen/texthooks
   rev: 0.7.1
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,7 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
   rev: v6.0.0
   hooks:
   - id: check-ast
-#  - id: trailing-whitespace
-#  - id: end-of-file-fixer
+    name: check abstract syntax tree
   - id: check-merge-conflict
   - id: check-case-conflict
   - id: check-illegal-windows-names

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,11 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
   - id: forbid-submodules
   - id: check-toml
   - id: check-yaml
+
+- repo: https://github.com/sirosen/texthooks
+  rev: 0.7.1
+  hooks:
+#  - id: fix-smartquotes
+  - id: fix-spaces
+  - id: fix-ligatures
+  - id: forbid-bidi-controls

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,6 @@
 
 repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 
-#- repo: https://github.com/astral-sh/ruff-pre-commit
-#  rev: v0.14.5
-#  hooks:
-#  - id: ruff-check
-#    name: ruff-check (see https://docs.astral.sh/ruff/rules)
-#    args: [--fix]
-#  - id: ruff-format
-
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0
   hooks:
@@ -42,6 +34,14 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
   - id: fix-spaces
   - id: fix-ligatures
   - id: forbid-bidi-controls
+
+#- repo: https://github.com/astral-sh/ruff-pre-commit
+#  rev: v0.14.5
+#  hooks:
+#  - id: ruff-check
+#    name: ruff-check (see https://docs.astral.sh/ruff/rules)
+#    args: [--fix]
+#  - id: ruff-format
 
 #- repo: https://github.com/sphinx-contrib/sphinx-lint
 #  rev: v1.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,13 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 #  hooks:
 #  - id: sphinx-lint
 
+#- repo: https://github.com/codespell-project/codespell
+#  rev: v2.4.1
+#  hooks:
+#  - id: codespell
+#    name: codespell (add false positives to pyproject.toml)
+#    args: [--write-changes]
+
 - repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.35.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,7 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 #  - id: name-tests-test
   - id: detect-private-key
   - id: fix-byte-order-marker
-#  - id: mixed-line-ending
+  - id: mixed-line-ending
   - id: forbid-submodules
-  - id: check-json
   - id: check-toml
   - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,11 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 #  hooks:
 #  - id: sphinx-lint
 
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.35.0
+  hooks:
+  - id: check-github-workflows
+
 - repo: https://github.com/abravalheri/validate-pyproject
   rev: v0.24.1
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
-# configuration file for pre-commit and pre-commit.ci
+# Configuration file for pre-commit and pre-commit.ci.
+#
+# To perform automated fixes, either run `pre-commit run --all-files`
+# or comment `pre-commit.ci autofix` on a pull request.
+
+ci:  # https://pre-commit.ci/#configuration
+  autofix_prs: false
+  autoupdate_schedule: monthly
 
 repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,5 +167,14 @@ ignore = [
     "E501",  # Ignore line too long
 ]
 
+[tool.codespell]
+skip = "*.png,*.jpg,*.jpeg,*cache*,*egg*,.git,.hypothesis,.idea,.nox,.tox,_build,venv,*.lock"
+# Add false positives found by codespell to ignore-words-list
+ignore-words-list = """
+fo,
+inout,
+tha,
+thi"""
+
 [tool.pylint]
 disable = ["line-too-long", "too-many-arguments",]


### PR DESCRIPTION
This PR adds an initial configuration for [pre-commit](https://pre-commit.com/) in `.pre-commit-config.yaml`.  The purpose of using pre-commit is to perform quality checks and enact automated fixes for new contributions and throughout the repository.  

 - [ ] To enable pre-commit in CI, a maintainer will need to go to the [`pre-commit.ci`](https://pre-commit.ci/) website and click on the button near the top to "Sign In With GitHub". That should lead you through the process of activating pre-commit as a check on pull requests.

Thus far, I've added a bunch of pre-commit hooks from various sources. I'm enabling hooks that are passing without changes, and commenting out hooks that would require changes to implement.  Some of these hooks would make changes to a wide variety of files, like the one for removing trailing whitespace. It'd probably work best to apply those changes in multiple pull requests.  The autoformatting hooks could likely be lumped together into large pull requests since they change style but don't change content, but a few of the hooks will require careful code review.  For `ruff check` specifically, it would make sense to do this in multiple smaller pull requests (e.g., subpackage by subpackage).

I hope this helps!
