### PR TITLE
Bug fix for erg-mepe loading routine of pa data

### DIFF
--- a/pyspedas/projects/erg/satellite/erg/mepe/mepe.py
+++ b/pyspedas/projects/erg/satellite/erg/mepe/mepe.py
@@ -104,8 +104,8 @@ def mepe(
     if notplot:
         initial_notplot_flag = True
 
-    if level == 'l3':
-        datatype = '3dflux'
+    if level == 'l3' and datatype not in ['3dflux', 'pa']:
+        datatype = 'pa'
 
     file_res = 3600. * 24
     prefix = 'erg_mepe_'+level + '_' + datatype + '_'


### PR DESCRIPTION
This bug fix is based on the fix provided by Tomo Hori [at]ISEE that was implemented 3 days ago in the pyspedas-plugin repository (https://github.com/ergsc-devel/pyspedas_plugin). 
Previously, level 3 pitch angle data could not be loaded using the pyspedas.projects.erg.mepe routine since it level='l3' automatically loaded datatype '3dflux' data, even if prompted for the pitch angle 'pa' datatype.
This fix allows to prompt for datatypes '3dflux' or 'pa' for level 3 data.