### PR TITLE
Change SWEAP pre-public URL from http to https

### DIFF
--- a/pyspedas/projects/psp/config.py
+++ b/pyspedas/projects/psp/config.py
@@ -3,7 +3,7 @@ import os
 CONFIG = {
     'local_data_dir': 'psp_data/',
     'remote_data_dir': 'https://spdf.gsfc.nasa.gov/pub/data/psp/',
-    'sweap_remote_data_dir': 'http://sweap.cfa.harvard.edu/data/sci/',
+    'sweap_remote_data_dir': 'https://sweap.cfa.harvard.edu/data/sci/',
     'fields_remote_data_dir': 'https://sprg.ssl.berkeley.edu/data/spp/data/sci/'
 }
 


### PR DESCRIPTION
In psp config file, edit SWEAP remote data dir from http to https to reflect recent server changes (fixes pre-public data access)