### PR TITLE
fix: use tvar2 (not tvar1) for interpolated variable name

### DIFF
--- a/pyspedas/tplot_tools/tplot_math/tinterp.py
+++ b/pyspedas/tplot_tools/tplot_math/tinterp.py
@@ -38,8 +38,8 @@ def tinterp(tvar1,tvar2,replace=False):
         pyspedas.tplot_tools.data_quants[tvar2] = new_tvar2
         return
     else:
-        pyspedas.tplot_tools.data_quants[tvar1 + '_tinterp'] = copy.deepcopy(new_tvar2)
-        pyspedas.tplot_tools.data_quants[tvar1 + '_tinterp'].attrs = copy.deepcopy(new_tvar2.attrs)
-        pyspedas.tplot_tools.data_quants[tvar1 + '_tinterp'].name = tvar1 + '_tinterp'
+        pyspedas.tplot_tools.data_quants[tvar2 + '_tinterp'] = copy.deepcopy(new_tvar2)
+        pyspedas.tplot_tools.data_quants[tvar2 + '_tinterp'].attrs = copy.deepcopy(new_tvar2.attrs)
+        pyspedas.tplot_tools.data_quants[tvar2 + '_tinterp'].name = tvar2 + '_tinterp'
 
-    return tvar1 + '_tinterp'
+    return tvar2 + '_tinterp'


### PR DESCRIPTION
The function is supposed to interpolate `tvar2` to the frequency of `tvar1`, and then either overwrite `tvar2` (`replace=True`) or create a new variable (`replace=False`). This new variable should be called `tvar2 + '_tinterp'`, but is currently called `tvar1 + '_tinterp'`.  which is misleading. Because if many variables are interpolated to the frequency of the same variable, this function will overwrite the same variable string `tvar1 + '_tinterp'`. 
After this fix, the interpolated variable will be called `tvar2 + '_tinterp'`. 

Best, 
Lena