### PR TITLE
fix: spec pseudovariable options (ytitle, zlog, etc.) silently discarded

### DIFF
--- a/pyspedas/tplot_tools/MPLPlotter/tplot.py
+++ b/pyspedas/tplot_tools/MPLPlotter/tplot.py
@@ -458,7 +458,7 @@ def tplot(variables,
                     if plot_extras.get('right_axis'):
                         pseudo_right_axis = True
 
-                if pseudo_right_axis or spec:
+                if pseudo_right_axis: # if pseudo_right_axis:?
                     plot_extras = None
                 else:
                     yaxis_options = var_quants.attrs['plot_options']['yaxis_opt']
@@ -532,6 +532,12 @@ def tplot(variables,
                     pseudo_show_colorbar=True
                 else:
                     pseudo_show_colorbar=False
+
+                var_attrs = pyspedas.tplot_tools.data_quants[var].attrs
+                var_is_spec = bool(var_attrs['plot_options']['extras'].get('spec'))
+                this_plot_extras = plot_extras if var_is_spec else None
+                this_zaxis_options = zaxis_options if var_is_spec else None
+                
                 tplot(var,
                       trange=trange,
                       return_plot_objects=return_plot_objects,
@@ -539,8 +545,8 @@ def tplot(variables,
                       fig=fig, axis=this_axis, display=False,
                       running_trace_count=traces_processed,
                       pseudo_idx=pseudo_idx,
-                      pseudo_xaxis_options=xaxis_options, pseudo_yaxis_options=yaxis_options, pseudo_zaxis_options=zaxis_options,
-                      pseudo_line_options=line_opts, pseudo_extra_options=plot_extras,
+                      pseudo_xaxis_options=xaxis_options, pseudo_yaxis_options=yaxis_options, pseudo_zaxis_options=this_zaxis_options,
+                      pseudo_line_options=line_opts, pseudo_extra_options=this_plot_extras,
                       pseudo_right_axis=pseudo_right_axis,
                       show_colorbar=pseudo_show_colorbar)
                 traces_processed += trace_count_thisvar


### PR DESCRIPTION
I ran into a bug when plotting a spectrogram tplot variable together with a horizontal line, combined into a single pseudovariable. 

Any options I set on the pseudovariable itself : `ytitle`, `ysubtitle`, `ylog`, `ztitle` etc were ignored when plotting. 
Tracked this down to tplot.py, lines 461–462:
```
if pseudo_right_axis or spec:
    plot_extras = None
```
Whenever the pseudovariable is flagged as a spectrogram (`spec=True`), its own yaxis_opt/zaxis_opt/line_opt/extras are discarded entirely instead of being read and passed down to the components during rendering. Removing `spec` from this condition fixes the options propagation.

That fix alone introduces a new bug. Once the pseudovariable's zaxis_options/plot_extras are passed down, they get forwarded to every component of the pseudovariable, including the plain line-plot component (the threshold line). Since plot_extras carries {'spec': 1, 'spec_dim_to_plot': ..., ...} from the spectrogram, the line component gets spec: 1 forced onto it too — so the renderer tries to treat its 1D line data as a 2D spectrogram, which breaks its rendering (the line disappears, and one of the colorbars is lost) and raises an IndexError in specplot.py (var_data.y[:,:] = ytp[:,:], since var_data.y is 1D there, not 2D).

Fix: 
In the loop that recursively plots each component of the pseudovariable, only forward `zaxis_options` and `plot_extras` to components that are themselves spectrograms, checked per-component via that component's own extras['spec']. `yaxis_options` and `line_opts` are still shared across all components as before, since the y-axis (e.g. the energy axis) is meant to be shared between the spectrogram and its overlaid line — only the spec-specific settings (z-axis, spec_dim_to_plot) needed to be restricted. 