### PR TITLE
Wire MMS TAI converters through generic utilities

### DIFF
--- a/pyspedas/projects/mms/mms_tai2unix.py
+++ b/pyspedas/projects/mms/mms_tai2unix.py
@@ -1,13 +1,18 @@
-import datetime
 import numpy as np
-from pyspedas.utilities.leap_seconds import load_leap_table
+from pyspedas.utilities.tai2unix import tai2unix
+from pyspedas.utilities.unix2tai import unix2tai
+
+
+def _as_float_array(values):
+    return np.atleast_1d(np.asarray(values, dtype=float))
 
 
 def mms_tai2unix(values):
     """
-    Converts MMS timestamps in TAI to unix timestamps
+    Converts MMS timestamps in TAI to unix timestamps.
 
-    Based on Mitsuo Oka's IDL code with the same name.
+    This MMS-specific function preserves the historical return shape while
+    delegating leap-second handling to the generic PySPEDAS converter.
 
     Input
     ---------
@@ -19,35 +24,14 @@ def mms_tai2unix(values):
         Array of time values as unix times
 
     """
-    if not isinstance(values, list) and not isinstance(values, np.ndarray):
-        values = [values]
-    table = load_leap_table()
-    tai_minus_unix = 378691200.0
-    juls = np.array(table['juls'])
-    values_juls = np.array(values)/86400.0 + datetime.date(1958, 1, 1).toordinal() + 1721424.5
-    out = np.zeros(len(values))
-    for idx, value in enumerate(values_juls):
-        loc_greater = np.argwhere(value > juls).flatten()
-        if len(loc_greater) == 0:
-            continue
-        last_loc = loc_greater[len(loc_greater)-1]
-        current_leap = float(table['leaps'][last_loc])
-        tinput_1970 = values[idx] - tai_minus_unix
-        out[idx] = tinput_1970 - current_leap
-    return out
+    return np.asarray(tai2unix(_as_float_array(values)))
 
-from astropy.time import Time
-
-MMS_TAI_MINUS_UNIX_TAI = 378691200.0
 
 def mms_unix2tai(values):
     """
     Convert UTC/POSIX unix timestamps to MMS TAI seconds since 1958-01-01 TAI.
     """
     scalar = np.isscalar(values)
-    arr = np.atleast_1d(values).astype(float)
-
-    t = Time(arr, format="unix", scale="utc")
-    out = t.tai.unix_tai + MMS_TAI_MINUS_UNIX_TAI
+    out = np.asarray(unix2tai(_as_float_array(values)))
 
     return out[0] if scalar else np.asarray(out)

--- a/pyspedas/projects/mms/tests/test_mms_data_rate_seg.py
+++ b/pyspedas/projects/mms/tests/test_mms_data_rate_seg.py
@@ -155,5 +155,29 @@ class SegmentTestCases(unittest.TestCase):
         rt_unix = np.array(mms_tai2unix(tai_times))
         assert_allclose(unix_times, rt_unix, atol=0.0001)
 
+    def test_mms_tai_unix_wrappers_match_generic_converters(self):
+        from pyspedas import tai2unix, unix2tai
+
+        dates = [
+            '2016-12-31 23:59:58',
+            '2016-12-31 23:59:59',
+            '2017-01-01 00:00:00',
+            '2017-01-01 00:00:01',
+        ]
+
+        unix_times = np.array(time_double(dates))
+        tai_times = unix2tai(unix_times)
+
+        assert_allclose(mms_unix2tai(unix_times), tai_times)
+        assert_allclose(mms_tai2unix(tai_times), tai2unix(tai_times))
+
+        scalar_tai = mms_unix2tai(unix_times[0])
+        self.assertTrue(np.isscalar(scalar_tai))
+
+        scalar_unix = mms_tai2unix(tai_times[0])
+        self.assertIsInstance(scalar_unix, np.ndarray)
+        self.assertEqual(scalar_unix.shape, (1,))
+        assert_allclose(scalar_unix[0], unix_times[0])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- route MMS TAI/Unix conversions through the generic `unix2tai` and `tai2unix` utilities
- remove duplicate MMS leap-table/Astropy conversion logic
- add regression coverage that MMS wrappers match the generic converters across the 2016 leap-second boundary while preserving existing scalar return behavior

Fixes #1378

## Tests
- `python -m pytest pyspedas/projects/mms/tests/test_mms_data_rate_seg.py::SegmentTestCases::test_tai2unix_scalar pyspedas/projects/mms/tests/test_mms_data_rate_seg.py::SegmentTestCases::test_tai2unix_array pyspedas/projects/mms/tests/test_mms_data_rate_seg.py::SegmentTestCases::test_tai_unix_conversions pyspedas/projects/mms/tests/test_mms_data_rate_seg.py::SegmentTestCases::test_mms_tai_unix_wrappers_match_generic_converters -q`
