### PR TITLE
Validate reversed MMS trange inputs

### DIFF
--- a/pyspedas/projects/mms/mms_get_local_files.py
+++ b/pyspedas/projects/mms/mms_get_local_files.py
@@ -64,7 +64,17 @@ def mms_get_local_files(probe, instrument, data_rate, level, datatype, trange, m
 
     file_name = 'mms'+probe+'_'+instrument+'_'+data_rate+'_'+level+r'(_)?.*_([0-9]{8,14})_v(\d+).(\d+).(\d+).cdf'
 
-    days = rrule(DAILY, dtstart=parse(parse(trange[0]).strftime('%Y-%m-%d')), until=parse(trange[1])-timedelta(seconds=1))
+    start_time = parse(trange[0])
+    end_time = parse(trange[1])
+    if start_time >= end_time:
+        logging.error(
+            "Invalid trange: start time %s must be before end time %s.",
+            trange[0],
+            trange[1],
+        )
+        return []
+
+    days = rrule(DAILY, dtstart=parse(start_time.strftime('%Y-%m-%d')), until=end_time-timedelta(seconds=1))
 
     if datatype == '' or datatype is None:
         level_and_dtype = level

--- a/pyspedas/projects/mms/mms_load_data.py
+++ b/pyspedas/projects/mms/mms_load_data.py
@@ -47,6 +47,14 @@ def mms_load_data(trange=['2015-10-16', '2015-10-17'], probe='1', data_rate='srv
     if isinstance(trange[1], float):
         trange[1] = time_string(trange[1])
 
+    if time_double(trange[0]) >= time_double(trange[1]):
+        logging.error(
+            "Invalid trange: start time %s must be before end time %s.",
+            trange[0],
+            trange[1],
+        )
+        return [] if available or CONFIG['download_only'] else None
+
     download_only = CONFIG['download_only']
 
     no_download = False

--- a/pyspedas/projects/mms/tests/test_mms_fpi.py
+++ b/pyspedas/projects/mms/tests/test_mms_fpi.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pyspedas
 from pyspedas import mms_load_fpi
+from pyspedas.projects.mms.mms_get_local_files import mms_get_local_files
 import unittest
 from numpy.testing import assert_allclose
 
@@ -43,6 +44,44 @@ class FPITestCases(unittest.TestCase):
     def test_load_spdf_data(self):
         data = mms_load_fpi(trange=['2015-10-16/14:00', '2015-10-16/15:00'], spdf=True)
         self.assertTrue(data_exists('mms1_dis_energyspectr_omni_fast'))
+
+    def test_invalid_reversed_trange(self):
+        invalid_trange = ['2019-05-20/00:00', '2018-09-21/00:01']
+
+        with self.assertLogs(level='ERROR') as log_context:
+            data = mms_load_fpi(trange=invalid_trange, no_update=True)
+
+        self.assertIsNone(data)
+        self.assertTrue(
+            any('Invalid trange' in message for message in log_context.output)
+        )
+
+        with self.assertLogs(level='ERROR'):
+            notplot_data = mms_load_fpi(
+                trange=invalid_trange,
+                no_update=True,
+                notplot=True,
+            )
+        self.assertIsNone(notplot_data)
+
+        with self.assertLogs(level='ERROR'):
+            available_data = mms_load_fpi(
+                trange=invalid_trange,
+                no_update=True,
+                available=True,
+            )
+        self.assertEqual(available_data, [])
+
+        with self.assertLogs(level='ERROR'):
+            local_files = mms_get_local_files(
+                '1',
+                'fpi',
+                'fast',
+                'l2',
+                'des-moms',
+                invalid_trange,
+            )
+        self.assertEqual(local_files, [])
 
     def test_load_small_brst_interval(self):
         data = mms_load_fpi(trange=['2015-10-16/13:06', '2015-10-16/13:07'], data_rate='brst', datatype=['dis-moms', 'dis-dist'], time_clip=True)


### PR DESCRIPTION
## Summary
- validate reversed MMS `trange` inputs before the loader falls through to remote/local file lookup
- add the same defensive guard to `mms_get_local_files()` for direct callers
- cover default, `notplot`, `available`, and direct local-file paths with a regression test

## Validation
- `python -m pytest pyspedas/projects/mms/tests/test_mms_fpi.py -k invalid_reversed_trange -q`

Fixes #1240
