### PR TITLE
Preserve store_data input dictionaries

### DIFF
--- a/pyspedas/tplot_tools/store_data.py
+++ b/pyspedas/tplot_tools/store_data.py
@@ -138,6 +138,12 @@ def store_data(name, data=None, delete=False, newname=None, attr_dict={}):
         pyspedas.tplot_tools.data_quants[name].attrs['plot_options']['extras'] = {}
         return True
 
+    # store_data consumes coordinate keys internally with pop(); copy the
+    # caller's dictionary so the original input can be reused. Arrays and
+    # other values are intentionally not copied here to avoid unnecessary
+    # bulk-data duplication.
+    data = data.copy()
+
     # if the data table doesn't contain an 'x', assume this is a non-record varying variable
     if 'x' not in data.keys():
         values = np.array(data.pop('y'))

--- a/pyspedas/utilities/tests/test_utilities_tplot_wildcard.py
+++ b/pyspedas/utilities/tests/test_utilities_tplot_wildcard.py
@@ -118,6 +118,16 @@ class UtilTestCases(unittest.TestCase):
             result = tplot_wildcard_expand(patt1, quiet=True)
             self.assertTrue(len(log.output) == 2)
 
+    def test_store_data_reuses_input_dict(self):
+        del_data("*")
+        data = {"x": [1, 2, 3], "y": [4, 5, 6]}
+
+        self.assertTrue(store_data("foo", data=data))
+        self.assertTrue(store_data("bar", data=data))
+        self.assertEqual(data, {"x": [1, 2, 3], "y": [4, 5, 6]})
+        self.assertTrue(data_exists("foo"))
+        self.assertTrue(data_exists("bar"))
+
     def test_tplot_wildcard_expand(self):
         # Test wildcard expansion against current tplot variables
         del_data("*")


### PR DESCRIPTION
## Summary
- shallow-copy `store_data()` input dictionaries before internal `pop()` calls consume top-level keys
- preserve list/pseudovariable behavior and avoid deep-copying bulk arrays
- add a regression that reuses the same input dict for two tplot variables and confirms the original top-level mapping remains unchanged

## Validation
- `python -m pytest pyspedas/utilities/tests/test_utilities_tplot_wildcard.py -k store_data_reuses_input_dict -q`

Fixes #994
