### PR TITLE
Document MMS credential cache reset

### DIFF
--- a/docs/source/mms.rst
+++ b/docs/source/mms.rst
@@ -9,6 +9,24 @@ The routines in this module can be used to load data from the Magnetospheric Mul
 
 Each of the MMS load routines has a short name, which is just the instrument name without the mms_load prefix.
 
+MMS SDC credentials
+-------------------
+Most public MMS science data can be loaded without credentials.  When an MMS
+loader needs authenticated LASP SDC access, PySPEDAS looks for saved
+credentials in ``~/mms_auth_info.pkl`` (created by PySPEDAS) and
+``~/mms_auth_info.sav`` (created by IDL SPEDAS).  If no saved credentials are
+found, the loader prompts for an SDC username; press Enter at the username
+prompt to continue with public access.
+
+When you enter a non-empty username and the LASP SDC password check succeeds,
+PySPEDAS saves the username and password in ``~/mms_auth_info.pkl`` for later
+loads.  This file contains saved credentials, so protect it like other password
+stores and delete it when you no longer want credentials cached.  If
+authentication starts failing after an account or password change, or if a
+stale credentials file causes confusing errors, delete ``~/mms_auth_info.pkl``
+(and ``~/mms_auth_info.sav`` if present) and rerun the loader with
+``always_prompt=True`` to enter fresh credentials.
+
 Fluxgate Magnetometer (FGM)
 -----------------------------
 Short name: pyspedas.projects.mms.fgm

--- a/pyspedas/projects/mms/mms_login_lasp.py
+++ b/pyspedas/projects/mms/mms_login_lasp.py
@@ -7,25 +7,37 @@ import logging
 import warnings
 
 
-def mms_login_lasp(always_prompt=False, headers={}):
+def mms_login_lasp(always_prompt=False, headers=None):
     """
-    This function logs the user into the SDC and returns a tuple with: (requests.Session object, username)
+    Log the user into the MMS Science Data Center (SDC).
+
+    Returns a tuple with (requests.Session object, username).  If no
+    credentials are available or credential validation fails, the returned
+    username is ``None`` and the session is configured for public access.
+
+    Saved credentials are read from ``~/mms_auth_info.pkl`` (PySPEDAS) or
+    ``~/mms_auth_info.sav`` (IDL SPEDAS).  Delete those files to reset stale
+    saved credentials before retrying with ``always_prompt=True``.
     """
+    if headers is None:
+        headers = {}
+
     homedir = os.path.expanduser("~")
+    auth_info_path = os.sep.join([homedir, "mms_auth_info.pkl"])
+    idl_auth_info_path = os.sep.join([homedir, "mms_auth_info.sav"])
     user_input_passwd = False
     saved_auth = None
 
     # try to read saved pickle
     try:
-        auth_file = open(os.sep.join([homedir, "mms_auth_info.pkl"]), "rb")
-        saved_auth = pickle.load(auth_file)
-        auth_file.close()
+        with open(auth_info_path, "rb") as auth_file:
+            saved_auth = pickle.load(auth_file)
     except FileNotFoundError:
         pass
 
     # try to read the IDL sav file
     try:
-        idl_auth_info = readsav(os.sep.join([homedir, "mms_auth_info.sav"]))
+        idl_auth_info = readsav(idl_auth_info_path)
         saved_auth = {
             "user": idl_auth_info["auth_info"][0][0].decode("utf-8"),
             "passwd": idl_auth_info["auth_info"][0][1].decode("utf-8"),
@@ -49,8 +61,18 @@ def mms_login_lasp(always_prompt=False, headers={}):
 
         user_input_passwd = True
     else:
-        user = saved_auth["user"]
-        passwd = saved_auth["passwd"]
+        try:
+            user = saved_auth["user"] or ""
+            passwd = saved_auth["passwd"] or ""
+        except (KeyError, TypeError):
+            logging.warning(
+                "Ignoring invalid MMS SDC credentials in %s or %s; using public access. "
+                "Delete the stale file and rerun with always_prompt=True to reset saved credentials.",
+                auth_info_path,
+                idl_auth_info_path,
+            )
+            user = ""
+            passwd = ""
 
     session = requests.Session()
 
@@ -66,20 +88,35 @@ def mms_login_lasp(always_prompt=False, headers={}):
                     timeout=5,
                     headers=headers,
                 )
-        except:
+        except Exception as exc:
+            logging.warning(
+                "Unable to verify MMS SDC credentials; using public access. "
+                "If authentication keeps failing, delete saved credentials at %s "
+                "and/or %s, then rerun with always_prompt=True. Error: %s",
+                auth_info_path,
+                idl_auth_info_path,
+                exc,
+            )
+            session.auth = None
             return session, None
 
         # check if the login failed
         if testget.status_code == 401:
-            logging.error('Invalid password for user: ' + str(user) + '; trying public access..')
+            logging.error(
+                "Invalid MMS SDC password for user %s; using public access. "
+                "If this came from saved credentials, delete %s and/or %s, "
+                "then rerun with always_prompt=True.",
+                user,
+                auth_info_path,
+                idl_auth_info_path,
+            )
+            session.auth = None
             user = None
 
     # only save the user's user/passwd if login was successful
     if user_input_passwd and user is not None:
-        saved_auth = pickle.dump(
-            {"user": user, "passwd": passwd},
-            open(os.sep.join([homedir, "mms_auth_info.pkl"]), "wb"),
-        )
+        with open(auth_info_path, "wb") as auth_file:
+            pickle.dump({"user": user, "passwd": passwd}, auth_file)
 
     if user == "":
         user = None

--- a/pyspedas/projects/mms/tests/test_mms_login_lasp.py
+++ b/pyspedas/projects/mms/tests/test_mms_login_lasp.py
@@ -1,0 +1,66 @@
+import os
+import pickle
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from pyspedas.projects.mms.mms_login_lasp import mms_login_lasp
+
+
+class MMSLoginLaspTestCases(unittest.TestCase):
+    def _write_saved_auth(self, home, payload):
+        with open(os.path.join(home, "mms_auth_info.pkl"), "wb") as auth_file:
+            pickle.dump(payload, auth_file)
+
+    @patch("pyspedas.projects.mms.mms_login_lasp.readsav", side_effect=FileNotFoundError)
+    @patch("requests.Session.get")
+    def test_invalid_saved_credentials_fall_back_to_public_access(self, mock_get, _mock_readsav):
+        mock_response = Mock()
+        mock_response.status_code = 401
+        mock_get.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as home:
+            self._write_saved_auth(home, {"user": "stale-user", "passwd": "stale-pass"})
+
+            with patch("pyspedas.projects.mms.mms_login_lasp.os.path.expanduser", return_value=home):
+                with self.assertLogs(level="ERROR") as log:
+                    session, user = mms_login_lasp()
+
+        self.assertIsNone(user)
+        self.assertIsNone(session.auth)
+        self.assertIn("using public access", "\n".join(log.output))
+        self.assertIn("mms_auth_info.pkl", "\n".join(log.output))
+        self.assertIn("mms_auth_info.sav", "\n".join(log.output))
+        self.assertIn("mms_auth_info.sav", "\n".join(log.output))
+
+    @patch("pyspedas.projects.mms.mms_login_lasp.readsav", side_effect=FileNotFoundError)
+    @patch("requests.Session.get")
+    def test_none_saved_user_is_treated_as_public_access(self, mock_get, _mock_readsav):
+        with tempfile.TemporaryDirectory() as home:
+            self._write_saved_auth(home, {"user": None, "passwd": "stale-pass"})
+
+            with patch("pyspedas.projects.mms.mms_login_lasp.os.path.expanduser", return_value=home):
+                session, user = mms_login_lasp()
+
+        self.assertIsNone(user)
+        self.assertIsNone(session.auth)
+        mock_get.assert_not_called()
+
+    @patch("pyspedas.projects.mms.mms_login_lasp.readsav", side_effect=FileNotFoundError)
+    @patch("requests.Session.get", side_effect=TimeoutError("network timeout"))
+    def test_credential_check_exception_falls_back_to_public_access(self, _mock_get, _mock_readsav):
+        with tempfile.TemporaryDirectory() as home:
+            self._write_saved_auth(home, {"user": "saved-user", "passwd": "saved-pass"})
+
+            with patch("pyspedas.projects.mms.mms_login_lasp.os.path.expanduser", return_value=home):
+                with self.assertLogs(level="WARNING") as log:
+                    session, user = mms_login_lasp()
+
+        self.assertIsNone(user)
+        self.assertIsNone(session.auth)
+        self.assertIn("Unable to verify MMS SDC credentials", "\n".join(log.output))
+        self.assertIn("mms_auth_info.pkl", "\n".join(log.output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- document the MMS LASP SDC credential cache files and reset workflow
- make `mms_login_lasp()` return a true public-access session after stale/invalid credential fallback
- add mocked regressions for stale saved credentials, `user=None`, and credential-check exceptions

Fixes #929

## Validation
- `python -m pytest pyspedas/projects/mms/tests/test_mms_login_lasp.py -q` (`3 passed in 1.48s`)

## Review
- Zhipu/GLM review gate: reviewed before PR; no blocking findings after should-fix updates
