### PR TITLE
Allow divide by scalar time series

### DIFF
--- a/pyspedas/tplot_tools/tplot_math/divide.py
+++ b/pyspedas/tplot_tools/tplot_math/divide.py
@@ -39,6 +39,8 @@ def divide(tvar1,tvar2,newname=None):
     # separate and divide data
     data1 = pyspedas.tplot_tools.data_quants[tvar1].values
     data2 = pyspedas.tplot_tools.data_quants[tv2].values
+    if data1.ndim > data2.ndim and data2.ndim == 1 and data1.shape[0] == data2.shape[0]:
+        data2 = data2.reshape((data2.shape[0],) + (1,) * (data1.ndim - 1))
     data = data1 / data2
     # store divided data
     if newname is None:

--- a/pyspedas/utilities/tests/test_math.py
+++ b/pyspedas/utilities/tests/test_math.py
@@ -230,6 +230,26 @@ class AnalysisTestCases(BaseTestCase):
         dt = tres("v1")
         self.assertEqual(dt, 1.0)
 
+    def test_divide_vector_by_scalar_tvar(self):
+        del_data("*")
+        times = [0.0, 1.0, 2.0]
+        vector = np.array([[2.0, 4.0, 6.0], [8.0, 12.0, 16.0], [15.0, 20.0, 25.0]])
+        scalar = np.array([2.0, 4.0, 5.0])
+        store_data("vector", data={"x": times, "y": vector})
+        store_data("scalar", data={"x": times, "y": scalar})
+
+        divide("vector", "scalar", newname="ratio")
+
+        ratio_t, ratio_d = get_data("ratio")
+        assert_array_equal(ratio_t, np.array(times))
+        assert_array_equal(ratio_d, vector / scalar[:, np.newaxis])
+
+        result = divide("vector", "scalar")
+        self.assertEqual(result, "vector")
+        updated_t, updated_d = get_data("vector")
+        assert_array_equal(updated_t, np.array(times))
+        assert_array_equal(updated_d, vector / scalar[:, np.newaxis])
+
     def test_tplot_spectools(self):
         del_data("*")
         # tpwrspc, pwrspc


### PR DESCRIPTION
## Summary
- allow `divide()` to divide vector/spectrogram-like tplot variables by a 1D scalar time series on the same time axis
- reshape the denominator only for the IDL-compatible vector-over-scalar case `(n, ...)/(n,)`
- add regression coverage for both `newname=` and in-place divide paths

Fixes #638

## Validation
- `python -m pytest pyspedas/utilities/tests/test_math.py -k 'tplot_arithmetic or divide_vector_by_scalar_tvar' -q` (`2 passed, 10 deselected in 1.90s`)

## Review
- Zhipu/GLM review gate: reviewed before PR; no blocking findings; optional in-place-path coverage added
