### PR TITLE
Fix HPCA He++ charge handling in flux conversion

### DIFF
--- a/pyspedas/projects/mms/particles/mms_convert_flux_units.py
+++ b/pyspedas/projects/mms/particles/mms_convert_flux_units.py
@@ -48,26 +48,33 @@ def mms_convert_flux_units(data_in, units=None):
     if units_out == 'psd':
         units_out = 'df_km'
 
-    # get mass of species
+    # Get the mass-to-charge factor used by the MMS HPCA flux <->
+    # distribution-function conversion.  For singly charged species this is
+    # the same as the ion mass number, but HPCA flux products are organized
+    # by energy-per-charge; multiply charged species must therefore use A/q
+    # (e.g., He++ -> 4/2 = 2, O++ -> 16/2 = 8).
     if species_lc == 'i':
-        A = 1.0  # H+
+        a_over_q = 1.0  # H+
     elif species_lc == 'proton':
-        A = 1.0  # H+
+        a_over_q = 1.0  # H+
     elif species_lc == 'hplus':
-        A = 1.0  # H+
+        a_over_q = 1.0  # H+
     elif species_lc == 'heplus':
-        A = 4.0  # He+
+        a_over_q = 4.0  # He+
     elif species_lc == 'heplusplus':
-        A = 4.0  # He++
+        a_over_q = 2.0  # He++
     elif species_lc == 'oplus':
-        A = 16.0  # O+
+        a_over_q = 16.0  # O+
     elif species_lc == 'oplusplus':
-        A = 16.0  # O++
+        a_over_q = 8.0  # O++
     elif species_lc == 'e':
-        A = 1.0/1836.0  # e-
+        a_over_q = 1.0/1836.0  # e-
+    else:
+        logging.error('Error, unknown particle species: %s', data_in['species'])
+        return None
 
     # scaling factor between df and flux units
-    flux_to_df = A**2.0 * 0.5447 * 1e6
+    flux_to_df = a_over_q**2.0 * 0.5447 * 1e6
 
     # convert between km^6 and cm^6 for df_km
     cm_to_km = 1e30

--- a/pyspedas/projects/mms/tests/test_mms_part_getspec.py
+++ b/pyspedas/projects/mms/tests/test_mms_part_getspec.py
@@ -1,7 +1,11 @@
 import unittest
 import numpy as np
 from pyspedas.projects.mms.particles.mms_part_getspec import mms_part_getspec
-from pyspedas.tplot_tools import data_exists, get_data, tplot_names, tplot, get_coords, get_units
+from pyspedas.projects.mms.particles.mms_convert_flux_units import mms_convert_flux_units
+from pyspedas.projects.mms.hpca_tools.hpca import mms_load_hpca
+from pyspedas.projects.mms.hpca_tools.mms_hpca_calc_anodes import mms_hpca_calc_anodes
+from pyspedas.projects.mms.hpca_tools.mms_hpca_spin_sum import mms_hpca_spin_sum
+from pyspedas.tplot_tools import data_exists, get_data, tplot_names, tplot, get_coords, get_units, del_data
 
 global_display=True
 
@@ -169,6 +173,74 @@ class PGSTests(unittest.TestCase):
                          instrument='hpca',
                          output='energy')
         self.assertTrue(data_exists('mms1_hpca_heplusplus_phase_space_density_energy'))
+
+    def test_hpca_multiply_charged_flux_unit_conversion(self):
+        # HPCA flux products are organized by energy-per-charge.  The unit
+        # conversion must therefore use A/q for multiply charged species
+        # (He++ and O++), while singly charged species keep their mass number.
+        energy = np.array([[1000.0]])
+        data = np.array([[1.0]])
+
+        def convert(species):
+            return mms_convert_flux_units({
+                'species': species,
+                'units_name': 'df_cm',
+                'energy': energy,
+                'data': data,
+            }, units='eflux')['data']
+
+        hplus = convert('hplus')
+        heplus = convert('heplus')
+        heplusplus = convert('heplusplus')
+        oplus = convert('oplus')
+        oplusplus = convert('oplusplus')
+
+        np.testing.assert_allclose(heplusplus, heplus * 4.0)
+        np.testing.assert_allclose(oplusplus, oplus * 4.0)
+        np.testing.assert_allclose(hplus, data * energy**2 / (0.5447e6) * 1e30)
+
+    def test_hpca_heplusplus_energy_flux_matches_spin_average(self):
+        # Regression for PySPEDAS issue #1313: He++ spectra generated from
+        # HPCA phase-space-density data were about 4x smaller than the HPCA
+        # spin-averaged L2 flux product when the conversion used A=4 instead
+        # of A/q=2.
+        del_data('*')
+        trange = ['2015-11-19/08:34:41', '2015-11-19/08:35:53']
+        mms_part_getspec(trange=trange,
+                         instrument='hpca',
+                         species='heplusplus',
+                         data_rate='brst',
+                         output='energy',
+                         units='flux',
+                         center_measurement=True,
+                         suffix='_charge_regression')
+        mms_load_hpca(trange=trange,
+                      data_rate='brst',
+                      datatype='ion',
+                      center_measurement=True)
+        mms_hpca_calc_anodes(fov=[0, 360])
+        mms_hpca_spin_sum(avg=True)
+
+        generated = get_data('mms1_hpca_heplusplus_phase_space_density_energy_charge_regression')
+        spin_avg = get_data('mms1_hpca_heplusplus_flux_elev_0-360_spin')
+        self.assertIsNotNone(generated)
+        self.assertIsNotNone(spin_avg)
+
+        ratios = []
+        spin_times = np.asarray(spin_avg.times)
+        for gen_index, gen_time in enumerate(generated.times):
+            spin_index = int(np.argmin(np.abs(spin_times - gen_time)))
+            gen_y = np.asarray(generated.y[gen_index], dtype=float)
+            spin_y = np.asarray(spin_avg.y[spin_index], dtype=float)
+            valid = np.isfinite(gen_y) & np.isfinite(spin_y) & (spin_y != 0.0)
+            ratios.extend((gen_y[valid] / spin_y[valid]).tolist())
+
+        ratios = np.asarray(ratios, dtype=float)
+        ratios = ratios[np.isfinite(ratios)]
+        self.assertGreater(ratios.size, 50)
+        median_ratio = np.nanmedian(ratios)
+        self.assertGreater(median_ratio, 0.75)
+        self.assertLess(median_ratio, 1.25)
 
     def test_pitch_angle_limits(self):
         # Regression test for application of pitch angle limits to energy spectra


### PR DESCRIPTION
## Summary

Fixes #1313.

This updates MMS HPCA flux / phase-space-density unit conversion for multiply charged ion species:

- use mass-to-charge (`A/q`) factors for He++ (`4/2 = 2`) and O++ (`16/2 = 8`) in `mms_convert_flux_units`
- keep singly charged species unchanged (`H+`, `He+`, `O+`, electrons)
- keep HPCA moments semantics separate: the distribution metadata still carries actual ion mass plus charge, so moment/temperature calculations continue to use actual mass rather than `A/q`
- add synthetic and actual-data regressions for the He++ factor-of-four discrepancy

The HPCA L2 flux products are organized by energy-per-charge; using mass number `A=4` for He++ made generated spectra about 4x too small relative to the HPCA spin-averaged L2 flux product. With `A/q=2`, the reproduced interval now gives a generated/spin median ratio of about 1.003.

## Validation

Targeted local checks on `fix/pyspedas-1313-hpca-charge-units` (`544e8eb`):

- `PYTHONPATH=$PWD /Users/huangzesen/anaconda3/bin/python -m pytest pyspedas/projects/mms/tests/test_mms_part_getspec.py::PGSTests::test_hpca_multiply_charged_flux_unit_conversion -q`
  - `1 passed in 5.24s`
- `PYTHONPATH=$PWD /Users/huangzesen/anaconda3/bin/python -m pytest pyspedas/projects/mms/tests/test_mms_part_getspec.py::PGSTests::test_hpca_heplusplus_energy_flux_matches_spin_average -q`
  - `1 passed in 10.39s`
- Selected HPCA smoke + new tests:
  - `test_hpca_srvy_hplus`
  - `test_hpca_srvy_heplus`
  - `test_hpca_srvy_heplusplus`
  - `test_hpca_srvy_oplus`
  - `test_hpca_multiply_charged_flux_unit_conversion`
  - `test_hpca_heplusplus_energy_flux_matches_spin_average`
  - result: `6 passed in 272.33s (0:04:32)`
- Post-fix ratio check on `2015-11-19/08:34:41`–`08:35:53`:
  - finite ratios: `187`
  - generated/spin median: `1.003072`
  - p25/p75: `0.990540` / `1.013852`
- `git diff --check`
  - passed

Not run to completion locally: the full modified `test_mms_part_getspec.py` file timed out after 900s in my local data-heavy run. The targeted HPCA coverage above passed, and CI should provide the project-standard matrix signal.

## Review

I also asked a local GLM/Zhipu reviewer to inspect the diff before opening this PR. Review verdict: no blockers, no should-fix items; safe to open PR within the validation boundary. Follow-up-only observations were to leave larger species-table cleanup and an unrelated `oplusplus` spin helper observation out of this focused bugfix.
