### PR TITLE
Removing MICA tests from quick_tests workflow

### DIFF
--- a/.github/workflows/quick_tests.yml
+++ b/.github/workflows/quick_tests.yml
@@ -322,8 +322,6 @@ jobs:
         coverage run -a -m  pyspedas.projects.themis.tests.test_themis
         echo Starting goes tests at `date`
         coverage run -a -m  pyspedas.projects.goes.tests.test_goes
-        echo Starting mica tests at `date`
-        coverage run -a -m  pyspedas.projects.mica.tests.test_mica
         echo Starting ulysses tests at `date`
         coverage run -a -m  pyspedas.projects.ulysses.tests.test_ulysses
         echo Starting solo tests at `date`


### PR DESCRIPTION
The MICA data server at mirl.unh.edu is unreliable, so I'm removing that test from quick_tests.  It will remain in the full coverage suite.