### PR TITLE
Eclipse spinmodel corrections

### DIFF
--- a/docs/source/themis_analysis.rst
+++ b/docs/source/themis_analysis.rst
@@ -32,6 +32,111 @@ Transformations
 
 .. autofunction:: pyspedas.projects.themis.ssl2dsl
 
+Eclipse Spin Model Corrections
+-------------------------------
+
+The THEMIS probes rely on a sun sensor to keep track of the times when the sun crosses the sun sensor during each spin.
+These crossing times are used (via a phase-locked loop in the onboard flight software) to drive an onboard spin sectoring
+clock that governs the production of particle data distributions and spin fits for the EFI and FGM instruments.
+
+On the ground, the sun sensor crossing times are used to estimate the spacecraft attitude throughout each spin of the probe.
+This is crucial for transforming the data from instrument coordinates (which spin with the spacecraft) to DSL coordinates
+(despun/solar/angular momentum, with the +X toward the sun. and +Z direction along the spin axis). From DSL coordinates, the
+information about spin axis right ascension and declination are used to transform the data into geophysically meaningful
+coordinates like GEI, GSE, GSM and others.
+
+From time to time, the THEMIS spacecraft pass through earth or moon shadows.  During these eclipse periods, no sun sensor
+crossing data is available. This upsets the onboard spin sectoring clock and spin fit algorithms, introducing a sudden,
+spurious spin angle offset that persists until the probe leaves the shadow and sun sensor data becomes available again.
+
+Another important eclipse effect pertains to the probe spin period.  During the eclipse, the probe begins to cool off.
+The thermal contraction of the probe (especially the long EFI wire booms) causes the probe to spin faster, reducing the
+spin period, in a rather complicated way that depends on the amount of propellant remaining, tank heater cycles, etc.
+
+The effect in the data is that the "estimated DSL" frame begins to rotate with respect to the "true DSL" frame,
+with spin phase errors accumulating during the eclipse.  Waveform data from the FGM, SCM, and EFI instruments
+will show a distinct sinusoidal variation due to the accumlating spin phase errors.  Spin-based data, like EFI and FGM
+spin fits, and particle data which is collected in "estimated DSL" coordinates. shows a similar coordinate frame
+rotation, plus an additional phase offset from the disruption to the onboard spin sectoring clock at eclipse entry.
+
+The FGM team has devised a procedure for modeling the evolution of the probe spin period through eclipses.
+The model is used to produce a set of theoretical sun sensor crossing times based on the spin period evolution.
+These artificial sun sensor crossing times can be used to supplement the pure sun sensor data, and remove most of
+the spin phase errors due to the eclipse effects.
+
+For correcting spin fit and particle data, an estimate of the constant spin phase offset is required.  This
+can be obtained by comparing FGM spin fit data with FGM waveform data.  The FGL data type is only
+available during fast survey time intervals, so this level of correction is only available for some
+eclipses.
+
+The eclipse spin modeling process isn't 100% successful: for some eclipses, the spin modeling fails to
+converge, and no corrections are produced for that eclipse.
+
+Therefore, during every eclipse, there are three possibilities:  no corrections at all;  partial corrections
+for waveform data types, but with uncorrected spin phase offsets for spin fits and particles; or full correction
+of waveform, spin fit, and particle data types.
+
+The THEMIS L2 data products do not include any attempts to use eclipse spin model corrections.  However,
+PySPEDAS includes some tools to apply the necessary corrections to the L2 data.
+
+THEMIS spin models
+^^^^^^^^^^^^^^^^^^^^
+
+The sun sensor crossing times are incorporated into the standard "spin model" represented by a set of variables
+in the THEMIS L1 STATE CDFs.  The spin model is implemented as an object with an `interp_t` method
+which can be used to get the spin number, spin period. spin phase, and other diagnostic quantities
+at any time.  The spin phase from the spin model, plus the spin axis right ascension and declination
+from other L1 state CDF variables, completely specify the spacecraft attitude and any instant, permitting
+coordinate transformations from the spinning spacecraft frame, to the despun DSL frame, and then to geophysical
+coordinate frames.  For example, in the THEMIS ssl2dsl routine, we have:
+
+.. code-block:: python
+
+    spinmodel_obj=get_spinmodel(probe=probe, correction_level=eclipse_correction_level)
+
+and later,
+
+.. code-block:: python
+
+    logging.info('Using spin model to calculate phase versus time...')
+    result = spinmodel_obj.interp_t(in_times, use_spinphase_correction=use_spinphase_correction)
+    spinmodel_phase = result.spinphase * pi / 180.0
+
+.. autofunction:: pyspedas.projects.themis.get_spinmodel
+.. automethod:: pyspedas.projects.themis.state_tools.spinmodel.spinmodel.Spinmodel.interp_t
+
+Note the correction_level parameter in the get_spinmodel() call:  this value specifies the level
+of eclipse spin model corrections to apply when calculating the spinmodel phase vs time. The default value
+is 0 (standard model only, no eclipse corrections), 1 (correction for eclipse spin period changes,
+suitable for waveform data), or 2 (full corrections including constant spin phase offset, suitable for EFI and
+FGM spin fits. and particle data products).
+
+Finding the spin model correction status of a given eclipse
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is often useful to know whether eclipse spin model corrections were partially or fully successful
+for a given eclipse.  This can be done with the spinmodel method eclipse_correction_status().
+
+.. automethod:: pyspedas.projects.themis.state_tools.spinmodel.spinmodel.Spinmodel.eclipse_correction_status
+
+Applying eclipse spinmodel corrections
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+PySPEDAS users will generally not have to worry about dealing directly with the spin model objects.
+Instead, we provide two more user-friendly methods to perform eclipse spin model corrections.
+
+The first option is to use apply_eclipse_corrections=True with the THEMIS load routines when working
+with THEMIS L2 data products.  Specifying this flag will apply the appropriate level of eclipse spin
+model corrections to each variable loaded.
+
+The other option, useful if the variable to be corrected is not one of the standard THEMIS L2 variables,
+is to call one of the following routines, depending on whether the data to be corrected consists of vectors,
+or tensors.  (Examples of tensor quantities include the pressure "ptens" and momentum flux "mftens" quantities
+found in the MOM, ESA, or SST L2 CDFs.  For THEMIS, they are represented as 6-element arrays. with the remaining
+three elements in the 3x3 rank 2 tensor obtained via symmetry.)
+
+.. autofunction:: pyspedas.projects.themis.eclipse_spinmodel_corrections_vector
+.. autofunction:: pyspedas.projects.themis.eclipse_spinmodel_corrections_tensor
 
 Electron density estimates from spacecraft potential
 ------------------------------------------------------

--- a/pyspedas/projects/themis/__init__.py
+++ b/pyspedas/projects/themis/__init__.py
@@ -23,5 +23,7 @@ from .state_tools.ssc_pre import ssc_pre
 from .state_tools.autoload_support import autoload_support
 from .state_tools import get_spinmodel
 from .cotrans import sse2sel,gse2sse,dsl2gse,ssl2dsl
+from .state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
+from .state_tools.spinmodel.eclipse_spinmodel_corrections_tensor import eclipse_spinmodel_corrections_tensor
 
 from .analysis import scpot2dens, scpot2dens_nishimura

--- a/pyspedas/projects/themis/__init__.py
+++ b/pyspedas/projects/themis/__init__.py
@@ -1,3 +1,10 @@
+from .state_tools.state import state
+from .state_tools.slp import slp
+from .state_tools.autoload_support import autoload_support
+from .state_tools import get_spinmodel
+from .cotrans import sse2sel,gse2sse,dsl2gse,ssl2dsl
+from .state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
+from .state_tools.spinmodel.eclipse_spinmodel_corrections_tensor import eclipse_spinmodel_corrections_tensor
 
 from .spacecraft.fields.fgm import fgm
 from .spacecraft.fields.fit import fit
@@ -15,15 +22,9 @@ from .spacecraft.particles.gmom import gmom
 from .ground.gmag import gmag
 from .ground.ask import ask
 
-from .state_tools.state import state
-from .state_tools.slp import slp
+
 from .state_tools.ssc import ssc
 from .state_tools.ssc_pre import ssc_pre
 
-from .state_tools.autoload_support import autoload_support
-from .state_tools import get_spinmodel
-from .cotrans import sse2sel,gse2sse,dsl2gse,ssl2dsl
-from .state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
-from .state_tools.spinmodel.eclipse_spinmodel_corrections_tensor import eclipse_spinmodel_corrections_tensor
 
 from .analysis import scpot2dens, scpot2dens_nishimura

--- a/pyspedas/projects/themis/cotrans/dsl2gse.py
+++ b/pyspedas/projects/themis/cotrans/dsl2gse.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 import pyspedas
 from pyspedas.cotrans_tools.cotrans_lib import subgei2gse
 from pyspedas.tplot_tools import data_exists, del_data, store_data, get_data, set_coords, get_coords
-from pyspedas.projects.themis import autoload_support
+from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
 
 
 def dsl2gse(name_in: str, name_out: str, isgsetodsl: bool = False, ignore_input_coord: bool = False,

--- a/pyspedas/projects/themis/cotrans/dsl2gse.py
+++ b/pyspedas/projects/themis/cotrans/dsl2gse.py
@@ -53,7 +53,21 @@ def dsl2gse(name_in: str, name_out: str, isgsetodsl: bool = False, ignore_input_
         return 0
 
     if probe is None:
-        probe = name_in[2]
+        if "tha_" in name_in:
+            probe = "a"
+        elif "thb_" in name_in:
+            probe = "b"
+        elif "thc_" in name_in:
+            probe = "c"
+        elif "thd_" in name_in:
+            probe = "d"
+        elif "the_" in name_in:
+            probe = "e"
+        elif "thf_" in name_in:
+            probe = "f"
+        else:
+            logging.error(f"Unable to determine probe letter from variable name {name_in}")
+            return 0
 
     if not ignore_input_coord:
         in_coord = get_coords(name_in)

--- a/pyspedas/projects/themis/cotrans/ssl2dsl.py
+++ b/pyspedas/projects/themis/cotrans/ssl2dsl.py
@@ -57,7 +57,21 @@ def ssl2dsl(name_in: str, name_out: str, isdsltossl: bool = False, ignore_input_
         return 0
 
     if probe is None:
-        probe=name_in[2]
+        if "tha_" in name_in:
+            probe = "a"
+        elif "thb_" in name_in:
+            probe = "b"
+        elif "thc_" in name_in:
+            probe = "c"
+        elif "thd_" in name_in:
+            probe = "d"
+        elif "the_" in name_in:
+            probe = "e"
+        elif "thf_" in name_in:
+            probe = "f"
+        else:
+            logging.error(f"Unable to determine probe letter from variable name {name_in}")
+            return 0
 
     autoload_support(varname=name_in, probe=probe, spinmodel=True)
     spinmodel_obj=get_spinmodel(probe=probe, correction_level=eclipse_correction_level)

--- a/pyspedas/projects/themis/spacecraft/fields/efi.py
+++ b/pyspedas/projects/themis/spacecraft/fields/efi.py
@@ -2,6 +2,11 @@
 import logging
 from pyspedas import wildcard_expand
 from pyspedas.projects.themis.load import load
+from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
+from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
+from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
+from pyspedas import wildcard_expand, time_string
+import logging
 
 
 def efi(trange=['2007-03-23', '2007-03-24'],
@@ -15,7 +20,8 @@ def efi(trange=['2007-03-23', '2007-03-24'],
         downloadonly=False,
         notplot=False,
         no_update=False,
-        time_clip=False):
+        time_clip=False,
+        apply_eclipse_corrections=False):
     """
     This function loads Electric Field Instrument (EFI) data
 
@@ -92,6 +98,10 @@ def efi(trange=['2007-03-23', '2007-03-24'],
             Time clip the variables to exactly the range specified
             in the trange keyword
             Default: False
+            
+        apply_eclipse_corrections: bool
+            If True, apply eclipse spin model corrections to output variables as appropriate.
+            Default: False
 
     Returns
     -------
@@ -136,9 +146,38 @@ def efi(trange=['2007-03-23', '2007-03-24'],
         logging.error("No valid datatypes selected")
         return []
 
-    return load(instrument='efi', trange=trange, level=level,
+    loaded_vars =  load(instrument='efi', trange=trange, level=level,
                 datatype=selected_datatype,
                 suffix=suffix, get_support_data=get_support_data,
                 varformat=varformat, varnames=varnames,
                 downloadonly=downloadonly, notplot=notplot,
                 probe=probe, time_clip=time_clip, no_update=no_update)
+    
+    if level=='l2' and apply_eclipse_corrections:
+        p = probe
+        autoload_support(probe=p, trange=trange, spinmodel=True)
+        sm_spinfit = get_spinmodel(probe=p, correction_level=2, quiet=True)
+        start_times, end_times, flags, flag_strings = sm_spinfit.eclipse_correction_status()
+        n = len(start_times)
+        if n > 0:
+            logging.info(f"Eclipse correction status for probe {probe}:")
+            for i in range(n):
+                logging.info(
+                    f"Eclipse {i + 1} of {n}: start: {time_string(start_times[i])}  end: {time_string(end_times[i])} status: {flag_strings[i]}"
+                )
+            probe_vars = wildcard_expand(loaded_vars, "th" + p + "_*")
+            for v in probe_vars:
+                if ("btotal" in v) or ("_q_" in v) :
+                    pass
+                elif "efs" in v:
+                    # These are spin fits, but they're not the *onboard* spin fits that rely on
+                    # the onboard spin sectoring clock. They won't suffer from the sudden-onset fixed
+                    # spin plan offset that happens when the onboard spin sectoring clock is disrupted.
+                    # So they should probably be corrected using the waveform model,
+                    # rather than the spin fit model.
+                    logging.info(f"Applying waveform eclipse corrections to {v}")
+                    eclipse_spinmodel_corrections_vector(v, p, spin_based=False)
+                else:
+                    logging.info(f"Applying waveform eclipse corrections to {v}")
+                    eclipse_spinmodel_corrections_vector(v, p, spin_based=False)
+

--- a/pyspedas/projects/themis/spacecraft/fields/fgm.py
+++ b/pyspedas/projects/themis/spacecraft/fields/fgm.py
@@ -1,6 +1,11 @@
 
 from pyspedas.projects.themis.load import load
-from pyspedas.tplot_tools import options
+from pyspedas.tplot_tools import options, time_string, wildcard_expand
+from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
+from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
+from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
+
+import logging
 
 def fgm(trange=['2007-03-23', '2007-03-24'],
         probe='c',
@@ -13,7 +18,8 @@ def fgm(trange=['2007-03-23', '2007-03-24'],
         downloadonly=False,
         notplot=False,
         no_update=False,
-        time_clip=False):
+        time_clip=False,
+        apply_eclipse_corrections:bool = False):
     """
     This function loads Fluxgate magnetometer (FGM) data
 
@@ -69,6 +75,10 @@ def fgm(trange=['2007-03-23', '2007-03-24'],
             in the trange keyword
             Default: False
 
+        apply_eclipse_correction: bool
+            If True, apply eclipse spinmodel corrections to applicable L2 quantities
+            Default: False
+
     Returns
     -------
     List of str
@@ -117,6 +127,28 @@ def fgm(trange=['2007-03-23', '2007-03-24'],
                     if 'th'+prb+'_'+fgm_type+'_btotal'+suffix in loaded_vars:
                         options('th'+prb+'_'+fgm_type+'_btotal'+suffix, 'ytitle', 'TH'+prb.upper()+' '+fgm_type.upper())
                         options('th'+prb+'_'+fgm_type+'_btotal'+suffix, 'legend_names', 'Bmag')
+
+    if 'l2' in level and apply_eclipse_corrections:
+        # List correction status for each eclipse
+        for p in probe:
+            autoload_support(probe=p, trange=trange, spinmodel=True)
+            sm_spinfit=get_spinmodel(probe=p,correction_level=2,quiet=True)
+            start_times, end_times, flags, flag_strings = sm_spinfit.eclipse_correction_status()
+            n = len(start_times)
+            if n > 0:
+                logging.info(f"Eclipse correction status for probe {probe}:")
+                for i in range(n):
+                    logging.info(f"Eclipse {i+1} of {n}: start: {time_string(start_times[i])}  end: {time_string(end_times[i])} status: {flag_strings[i]}")
+                probe_vars = wildcard_expand(loaded_vars,'th'+p+'_*')
+                for v in probe_vars:
+                    if ('btotal' in v) or ('ssl' in v):
+                        pass
+                    elif 'fgs' in v:
+                        logging.info(f"Applying spin fit eclipse corrections to {v}")
+                        eclipse_spinmodel_corrections_vector(v, p, spin_based=True)
+                    else:
+                        logging.info(f"Applying waveform eclipse corrections to {v}")
+                        eclipse_spinmodel_corrections_vector(v, p, spin_based=False)
 
     return loaded_vars
 

--- a/pyspedas/projects/themis/spacecraft/fields/fit.py
+++ b/pyspedas/projects/themis/spacecraft/fields/fit.py
@@ -1,6 +1,12 @@
 from pyspedas.projects.themis.load import load
 from pyspedas.utilities.is_gzip import is_gzip
 import gzip
+from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
+from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
+from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
+from pyspedas import wildcard_expand, time_string
+import logging
+
 
 def fit(trange=['2007-03-23', '2007-03-24'],
         probe='c',
@@ -12,7 +18,8 @@ def fit(trange=['2007-03-23', '2007-03-24'],
         downloadonly=False,
         notplot=False,
         no_update=False,
-        time_clip=False):
+        time_clip=False,
+        apply_eclipse_corrections=False):
     """
     This function loads THEMIS FIT data
 
@@ -68,6 +75,9 @@ def fit(trange=['2007-03-23', '2007-03-24'],
             in the trange keyword
             Default: False
 
+        apply_eclipse_corrections: bool
+            If available, apply eclipse spinmodel corrections to L2 variables
+
     Returns
     -------
     List of str
@@ -82,11 +92,38 @@ def fit(trange=['2007-03-23', '2007-03-24'],
         >>> tplot(['thd_fgs_gse', 'thd_efs_dot0_gse'])
 
     """
-    return load(instrument='fit', trange=trange, level=level,
+    loaded_vars = load(instrument='fit', trange=trange, level=level,
                 suffix=suffix, get_support_data=get_support_data,
                 varformat=varformat, varnames=varnames,
                 downloadonly=downloadonly, notplot=notplot,
                 probe=probe, time_clip=time_clip, no_update=no_update)
+
+    if not isinstance(level, list):
+        level = [level]
+
+    if not isinstance(probe, list):
+        probe = [probe]
+
+    for l in level:
+        for p in probe:
+            if l == 'l2' and apply_eclipse_corrections:
+                autoload_support(probe=p, trange=trange, spinmodel=True)
+                sm_spinfit=get_spinmodel(probe=p,correction_level=2,quiet=True)
+                start_times, end_times, flags, flag_strings = sm_spinfit.eclipse_correction_status()
+                n = len(start_times)
+                if n > 0:
+                    logging.info(f"Eclipse correction status for probe {probe}:")
+                    for i in range(n):
+                        logging.info(f"Eclipse {i+1} of {n}: start: {time_string(start_times[i])}  end: {time_string(end_times[i])} status: {flag_strings[i]}")
+                    probe_vars = wildcard_expand(loaded_vars,'th'+p+'_*')
+                    for v in probe_vars:
+                        if ('btotal' in v) or ('sigma' in v) or ('_fit_' in v) or ('hed' in v):
+                            pass
+                        elif 'fgs' in v or 'efs' in v:
+                            logging.info(f"Applying spin fit eclipse corrections to {v}")
+                            eclipse_spinmodel_corrections_vector(v, p, spin_based=True)
+
+    return loaded_vars
 
 
 def cal_fit(probe='a', no_cal=False):

--- a/pyspedas/projects/themis/spacecraft/fields/scm.py
+++ b/pyspedas/projects/themis/spacecraft/fields/scm.py
@@ -1,5 +1,10 @@
 
 from pyspedas.projects.themis.load import load
+from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
+from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
+from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
+from pyspedas import wildcard_expand, time_string
+import logging
 
 
 def scm(trange=['2007-03-23', '2007-03-24'],
@@ -12,7 +17,8 @@ def scm(trange=['2007-03-23', '2007-03-24'],
         downloadonly=False,
         notplot=False,
         no_update=False,
-        time_clip=False):
+        time_clip=False,
+        apply_eclipse_corrections=False):
     """
     This function loads Search-coil magnetometer (SCM) data
 
@@ -68,6 +74,10 @@ def scm(trange=['2007-03-23', '2007-03-24'],
             in the trange keyword
             Default: False
 
+        apply_eclipse_correctios: bool
+            If True, apply eclipse spinmodel corrections to output variables as appropriate
+            Default: False
+
     Returns
     -------
     List of str
@@ -82,8 +92,36 @@ def scm(trange=['2007-03-23', '2007-03-24'],
         >>> tplot(['thd_scf_btotal', 'thd_scf_gse'])
 
     """
-    return load(instrument='scm', trange=trange, level=level,
+    loaded_vars =  load(instrument='scm', trange=trange, level=level,
                 suffix=suffix, get_support_data=get_support_data,
                 varformat=varformat, varnames=varnames,
                 downloadonly=downloadonly, notplot=notplot,
                 probe=probe, time_clip=time_clip, no_update=no_update)
+    
+    if not isinstance(level, list):
+        level = [level]
+
+    if not isinstance(probe, list):
+        probe = [probe]
+        
+    for l in level:
+        for p in probe:
+            if l == 'l2' and apply_eclipse_corrections:
+                autoload_support(probe=p, trange=trange, spinmodel=True)
+                sm_spinfit=get_spinmodel(probe=p,correction_level=2,quiet=True)
+                start_times, end_times, flags, flag_strings = sm_spinfit.eclipse_correction_status()
+                n = len(start_times)
+                if n > 0:
+                    logging.info(f"Eclipse correction status for probe {probe}:")
+                    for i in range(n):
+                        logging.info(f"Eclipse {i+1} of {n}: start: {time_string(start_times[i])}  end: {time_string(end_times[i])} status: {flag_strings[i]}")
+                    probe_vars = wildcard_expand(loaded_vars,'th'+p+'_*')
+                    for v in probe_vars:
+                        if 'btotal' in v:
+                            pass
+                        else:
+                            logging.info(f"Applying waveform eclipse corrections to {v}")
+                            eclipse_spinmodel_corrections_vector(v, p, spin_based=False)
+
+    return loaded_vars
+

--- a/pyspedas/projects/themis/spacecraft/particles/esa.py
+++ b/pyspedas/projects/themis/spacecraft/particles/esa.py
@@ -1,5 +1,11 @@
 from pyspedas.projects.themis.load import load
 import pyspedas
+from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
+from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
+from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_tensor import eclipse_spinmodel_corrections_tensor
+from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
+from pyspedas import wildcard_expand, time_string
+import logging
 
 def esa(trange=['2007-03-23', '2007-03-24'],
         probe='c',
@@ -11,7 +17,8 @@ def esa(trange=['2007-03-23', '2007-03-24'],
         downloadonly=False,
         notplot=False,
         no_update=False,
-        time_clip=False):
+        time_clip=False,
+        apply_eclipse_corrections=False):
     """
     This function loads Electrostatic Analyzer (ESA) data
 
@@ -67,6 +74,9 @@ def esa(trange=['2007-03-23', '2007-03-24'],
             in the trange keyword
             Default: False
 
+        apply_eclipse_corrections: bool
+            If True, apply eclipse spin model corrections to L2 output variables as appropriate.
+
     Returns
     -------
     List of str
@@ -81,10 +91,40 @@ def esa(trange=['2007-03-23', '2007-03-24'],
         >>> tplot(['thd_peif_density', 'thd_peif_vthermal'])
 
     """
-    outvars = load(instrument='esa', trange=trange, level=level,
+    loaded_vars = load(instrument='esa', trange=trange, level=level,
                    suffix=suffix, get_support_data=get_support_data,
                    varformat=varformat, varnames=varnames,
                    downloadonly=downloadonly, notplot=notplot,
                    probe=probe, time_clip=time_clip, no_update=no_update)
 
-    return outvars
+    if not isinstance(level, list):
+        level = [level]
+
+    if not isinstance(probe, list):
+        probe = [probe]
+
+    for l in level:
+        for p in probe:
+            if l == 'l2' and apply_eclipse_corrections:
+                autoload_support(probe=p, trange=trange, spinmodel=True)
+                sm_spinfit=get_spinmodel(probe=p,correction_level=2,quiet=True)
+                start_times, end_times, flags, flag_strings = sm_spinfit.eclipse_correction_status()
+                n = len(start_times)
+                if n > 0:
+                    logging.info(f"Eclipse correction status for probe {probe}:")
+                    for i in range(n):
+                        logging.info(f"Eclipse {i+1} of {n}: start: {time_string(start_times[i])}  end: {time_string(end_times[i])} status: {flag_strings[i]}")
+                    probe_vars = wildcard_expand(loaded_vars,'th'+p+'_*')
+                    for v in probe_vars:
+                        if ('mag' in v) or ('_en_' in v):
+                            logging.info(f"Skipping eclipse corrections for {v}")
+                        elif ("mftens" in v) or ("ptens" in v):
+                            logging.info(f"Applying particle tensor eclipse corrections to {v}")
+                            eclipse_spinmodel_corrections_tensor(v, p, spin_based=True)
+                        elif ("velocity" in v) or ("eflux" in v) or ("flux" in v):
+                            logging.info(f"Applying particle vector eclipse corrections to {v}")
+                            eclipse_spinmodel_corrections_vector(v, p, spin_based=True)
+                        else:
+                            logging.info(f"Skipping eclipse corrections for {v}")
+
+    return loaded_vars

--- a/pyspedas/projects/themis/spacecraft/particles/esa.py
+++ b/pyspedas/projects/themis/spacecraft/particles/esa.py
@@ -116,12 +116,13 @@ def esa(trange=['2007-03-23', '2007-03-24'],
                         logging.info(f"Eclipse {i+1} of {n}: start: {time_string(start_times[i])}  end: {time_string(end_times[i])} status: {flag_strings[i]}")
                     probe_vars = wildcard_expand(loaded_vars,'th'+p+'_*')
                     for v in probe_vars:
-                        if ('mag' in v) or ('_en_' in v):
+                        if ('mag' in v) or ('_en_' in v) or ('symm_ang' in v):
+                            # Field aligned quantities, spectra, and scalars don't get transformed
                             logging.info(f"Skipping eclipse corrections for {v}")
                         elif ("mftens" in v) or ("ptens" in v):
                             logging.info(f"Applying particle tensor eclipse corrections to {v}")
                             eclipse_spinmodel_corrections_tensor(v, p, spin_based=True)
-                        elif ("velocity" in v) or ("eflux" in v) or ("flux" in v):
+                        elif ("velocity" in v) or ("eflux" in v) or ("flux" in v) or ("symm" in v):
                             logging.info(f"Applying particle vector eclipse corrections to {v}")
                             eclipse_spinmodel_corrections_vector(v, p, spin_based=True)
                         else:

--- a/pyspedas/projects/themis/spacecraft/particles/gmom.py
+++ b/pyspedas/projects/themis/spacecraft/particles/gmom.py
@@ -1,5 +1,11 @@
 
 from pyspedas.projects.themis.load import load
+from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
+from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
+from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_tensor import eclipse_spinmodel_corrections_tensor
+from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
+from pyspedas import wildcard_expand, time_string
+import logging
 
 
 def gmom(trange=['2007-03-23', '2007-03-24'],
@@ -12,7 +18,8 @@ def gmom(trange=['2007-03-23', '2007-03-24'],
          downloadonly=False,
          notplot=False,
          no_update=False,
-         time_clip=False):
+         time_clip=False,
+         apply_eclipse_corrections=False):
     """
     This function loads THEMIS Level 2 ground
     calculated combined ESA+SST moments.
@@ -69,6 +76,10 @@ def gmom(trange=['2007-03-23', '2007-03-24'],
             in the trange keyword
             Default: False
 
+        apply_eclipse_corrections: bool
+            If True, apply eclipse spinmodel corrections to output variables as appropriate
+            Default: False
+
     Returns
     -------
     List of str
@@ -85,8 +96,39 @@ def gmom(trange=['2007-03-23', '2007-03-24'],
 
 
     """
-    return load(instrument='gmom', trange=trange, level=level,
+    loaded_vars = load(instrument='gmom', trange=trange, level=level,
                 suffix=suffix, get_support_data=get_support_data,
                 varformat=varformat, varnames=varnames,
                 downloadonly=downloadonly, notplot=notplot,
                 probe=probe, time_clip=time_clip, no_update=no_update)
+    if not isinstance(level, list):
+        level = [level]
+
+    if not isinstance(probe, list):
+        probe = [probe]
+
+    for l in level:
+        for p in probe:
+            if l == 'l2' and apply_eclipse_corrections:
+                autoload_support(probe=p, trange=trange, spinmodel=True)
+                sm_spinfit=get_spinmodel(probe=p,correction_level=2,quiet=True)
+                start_times, end_times, flags, flag_strings = sm_spinfit.eclipse_correction_status()
+                n = len(start_times)
+                if n > 0:
+                    logging.info(f"Eclipse correction status for probe {probe}:")
+                    for i in range(n):
+                        logging.info(f"Eclipse {i+1} of {n}: start: {time_string(start_times[i])}  end: {time_string(end_times[i])} status: {flag_strings[i]}")
+                    probe_vars = wildcard_expand(loaded_vars,'th'+p+'_*')
+                    for v in probe_vars:
+                        if ('mag' in v) or ('_en_' in v) :
+                            logging.info(f"Skipping eclipse corrections for {v}")
+                        elif ('mftens' in v) or ('ptens' in v):
+                            logging.info(f"Applying particle tensor eclipse corrections to {v}")
+                            eclipse_spinmodel_corrections_tensor(v, p, spin_based=True)
+                        elif ('velocity' in v) or ('eflux' in v) or ('flux' in v):
+                            logging.info(f"Applying particle vector eclipse corrections to {v}")
+                            eclipse_spinmodel_corrections_vector(v, p, spin_based=True)
+                        else:
+                            logging.info(f"Skipping eclipse corrections for {v}")
+
+    return loaded_vars

--- a/pyspedas/projects/themis/spacecraft/particles/mom.py
+++ b/pyspedas/projects/themis/spacecraft/particles/mom.py
@@ -122,12 +122,17 @@ def mom(trange=['2008-03-23', '2008-03-24'],
                         logging.info(f"Eclipse {i+1} of {n}: start: {time_string(start_times[i])}  end: {time_string(end_times[i])} status: {flag_strings[i]}")
                     probe_vars = wildcard_expand(loaded_vars,'th'+p+'_*')
                     for v in probe_vars:
-                        if ('mag' in v):
+                        if ('mag' in v) or ('symm_ang' in v):
+                            # Field aligned quantities are not in DSL coordinates
+                            # Scalars do not get transformed
                             logging.info(f"Skipping eclipse corrections for {v}")
                         elif ('mftens' in v) or ('ptens' in v):
                             logging.info(f"Applying particle tensor eclipse corrections to {v}")
                             eclipse_spinmodel_corrections_tensor(v, p, spin_based=True)
-                        elif ('velocity' in v) or ('eflux' in v) or ('flux' in v):
+                        elif ('velocity' in v) or ('eflux' in v) or ('flux' in v) or ('symm' in v):
+                            # There is a t3 moment that's a three-element array, but it's not a DSL
+                            # vector, but a set of eigenvalues that relate to the eigenvectors of the
+                            # t3x3 temperature tensor, not DSL X,Y, and Z components
                             logging.info(f"Applying particle vector eclipse corrections to {v}")
                             eclipse_spinmodel_corrections_vector(v, p, spin_based=True)
                         else:

--- a/pyspedas/projects/themis/spacecraft/particles/mom.py
+++ b/pyspedas/projects/themis/spacecraft/particles/mom.py
@@ -2,6 +2,7 @@
 from pyspedas.projects.themis.load import load
 from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
 from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
+from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_tensor import eclipse_spinmodel_corrections_tensor
 from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
 from pyspedas import wildcard_expand, time_string
 import logging
@@ -122,12 +123,16 @@ def mom(trange=['2008-03-23', '2008-03-24'],
                     probe_vars = wildcard_expand(loaded_vars,'th'+p+'_*')
                     for v in probe_vars:
                         if ('mag' in v):
-                            pass
+                            logging.info(f"Skipping eclipse corrections for {v}")
                         elif ('mftens' in v) or ('ptens' in v):
                             logging.info(f"Applying particle tensor eclipse corrections to {v}")
-                            eclipse_spinmodel_corrections_vector(v, p, spin_based=True)
+                            eclipse_spinmodel_corrections_tensor(v, p, spin_based=True)
                         elif ('velocity' in v) or ('eflux' in v) or ('flux' in v):
                             logging.info(f"Applying particle vector eclipse corrections to {v}")
                             eclipse_spinmodel_corrections_vector(v, p, spin_based=True)
+                        else:
+                            logging.info(f"Skipping eclipse corrections for {v}")
+
+
 
     return loaded_vars

--- a/pyspedas/projects/themis/spacecraft/particles/mom.py
+++ b/pyspedas/projects/themis/spacecraft/particles/mom.py
@@ -1,5 +1,10 @@
 
 from pyspedas.projects.themis.load import load
+from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
+from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
+from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
+from pyspedas import wildcard_expand, time_string
+import logging
 
 
 def mom(trange=['2008-03-23', '2008-03-24'],
@@ -12,7 +17,8 @@ def mom(trange=['2008-03-23', '2008-03-24'],
         downloadonly=False,
         notplot=False,
         no_update=False,
-        time_clip=False):
+        time_clip=False,
+        apply_eclipse_corrections=False):
     """
     This function loads THEMIS moments data
 
@@ -72,6 +78,9 @@ def mom(trange=['2008-03-23', '2008-03-24'],
             in the trange keyword
             Default: False
 
+        apply_eclipse_corrections: bool
+            If True, apply eclipse spin model corrections to output variables as appropriate.
+            Default: False
     Returns
     -------
     List of str
@@ -87,8 +96,38 @@ def mom(trange=['2008-03-23', '2008-03-24'],
 
 
     """
-    return load(instrument='mom', trange=trange, level=level,
+    loaded_vars = load(instrument='mom', trange=trange, level=level,
                 suffix=suffix, get_support_data=get_support_data,
                 varformat=varformat, varnames=varnames,
                 downloadonly=downloadonly, notplot=notplot,
                 probe=probe, time_clip=time_clip, no_update=no_update)
+
+    if not isinstance(level, list):
+        level = [level]
+
+    if not isinstance(probe, list):
+        probe = [probe]
+
+    for l in level:
+        for p in probe:
+            if l == 'l2' and apply_eclipse_corrections:
+                autoload_support(probe=p, trange=trange, spinmodel=True)
+                sm_spinfit=get_spinmodel(probe=p,correction_level=2,quiet=True)
+                start_times, end_times, flags, flag_strings = sm_spinfit.eclipse_correction_status()
+                n = len(start_times)
+                if n > 0:
+                    logging.info(f"Eclipse correction status for probe {probe}:")
+                    for i in range(n):
+                        logging.info(f"Eclipse {i+1} of {n}: start: {time_string(start_times[i])}  end: {time_string(end_times[i])} status: {flag_strings[i]}")
+                    probe_vars = wildcard_expand(loaded_vars,'th'+p+'_*')
+                    for v in probe_vars:
+                        if ('mag' in v):
+                            pass
+                        elif ('mftens' in v) or ('ptens' in v):
+                            logging.info(f"Applying particle tensor eclipse corrections to {v}")
+                            eclipse_spinmodel_corrections_vector(v, p, spin_based=True)
+                        elif ('velocity' in v) or ('eflux' in v) or ('flux' in v):
+                            logging.info(f"Applying particle vector eclipse corrections to {v}")
+                            eclipse_spinmodel_corrections_vector(v, p, spin_based=True)
+
+    return loaded_vars

--- a/pyspedas/projects/themis/spacecraft/particles/sst.py
+++ b/pyspedas/projects/themis/spacecraft/particles/sst.py
@@ -140,12 +140,13 @@ def sst(trange=['2007-03-23', '2007-03-24'],
                         logging.info(f"Eclipse {i+1} of {n}: start: {time_string(start_times[i])}  end: {time_string(end_times[i])} status: {flag_strings[i]}")
                     probe_vars = wildcard_expand(loaded_vars,'th'+p+'_*')
                     for v in probe_vars:
-                        if ('mag' in v) or ('_en_' in v):
+                        if ('mag' in v) or ('_en_' in v) or ('symm_ang' in v):
+                            # Field aligned quantities, spectra, and scalars do not get transformed
                             logging.info(f"Skipping eclipse corrections for {v}")
                         elif ("mftens" in v) or ("ptens" in v):
                             logging.info(f"Applying particle tensor eclipse corrections to {v}")
                             eclipse_spinmodel_corrections_tensor(v, p, spin_based=True)
-                        elif ("velocity" in v) or ("eflux" in v) or ("flux" in v):
+                        elif ("velocity" in v) or ("eflux" in v) or ("flux" in v) or ('symm' in v):
                             logging.info(f"Applying particle vector eclipse corrections to {v}")
                             eclipse_spinmodel_corrections_vector(v, p, spin_based=True)
                         else:

--- a/pyspedas/projects/themis/spacecraft/particles/sst.py
+++ b/pyspedas/projects/themis/spacecraft/particles/sst.py
@@ -1,5 +1,11 @@
 
 from pyspedas.projects.themis.load import load
+from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
+from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
+from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_tensor import eclipse_spinmodel_corrections_tensor
+from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
+from pyspedas import wildcard_expand, time_string
+import logging
 
 
 def sst(trange=['2007-03-23', '2007-03-24'],
@@ -12,7 +18,8 @@ def sst(trange=['2007-03-23', '2007-03-24'],
         downloadonly=False,
         notplot=False,
         no_update=False,
-        time_clip=False):
+        time_clip=False,
+        apply_eclipse_corrections=False):
     """
     This function loads Solid State Telescope (SST) data
 
@@ -68,6 +75,10 @@ def sst(trange=['2007-03-23', '2007-03-24'],
             in the trange keyword
             Default: False
 
+        apply_eclipse_corrections: bool
+            if True, apply eclipse spinmodel corrections to L2 output variables as appropriate.
+            Default: False
+
     Returns
     -------
     List of str
@@ -104,8 +115,40 @@ def sst(trange=['2007-03-23', '2007-03-24'],
 
 
     """
-    return load(instrument='sst', trange=trange, level=level,
+    loaded_vars = load(instrument='sst', trange=trange, level=level,
                 suffix=suffix, get_support_data=get_support_data,
                 varformat=varformat, varnames=varnames,
                 downloadonly=downloadonly, notplot=notplot,
                 probe=probe, time_clip=time_clip, no_update=no_update)
+
+    if not isinstance(level, list):
+        level = [level]
+
+    if not isinstance(probe, list):
+        probe = [probe]
+
+    for l in level:
+        for p in probe:
+            if l == 'l2' and apply_eclipse_corrections:
+                autoload_support(probe=p, trange=trange, spinmodel=True)
+                sm_spinfit=get_spinmodel(probe=p,correction_level=2,quiet=True)
+                start_times, end_times, flags, flag_strings = sm_spinfit.eclipse_correction_status()
+                n = len(start_times)
+                if n > 0:
+                    logging.info(f"Eclipse correction status for probe {probe}:")
+                    for i in range(n):
+                        logging.info(f"Eclipse {i+1} of {n}: start: {time_string(start_times[i])}  end: {time_string(end_times[i])} status: {flag_strings[i]}")
+                    probe_vars = wildcard_expand(loaded_vars,'th'+p+'_*')
+                    for v in probe_vars:
+                        if ('mag' in v) or ('_en_' in v):
+                            logging.info(f"Skipping eclipse corrections for {v}")
+                        elif ("mftens" in v) or ("ptens" in v):
+                            logging.info(f"Applying particle tensor eclipse corrections to {v}")
+                            eclipse_spinmodel_corrections_tensor(v, p, spin_based=True)
+                        elif ("velocity" in v) or ("eflux" in v) or ("flux" in v):
+                            logging.info(f"Applying particle vector eclipse corrections to {v}")
+                            eclipse_spinmodel_corrections_vector(v, p, spin_based=True)
+                        else:
+                            logging.info(f"Skipping eclipse corrections for {v}")
+
+    return loaded_vars

--- a/pyspedas/projects/themis/state_tools/autoload_support.py
+++ b/pyspedas/projects/themis/state_tools/autoload_support.py
@@ -3,7 +3,8 @@ import pyspedas
 import pyspedas.projects.themis
 from pyspedas.tplot_tools import data_exists, get_timespan, time_double
 from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
-import pyspedas
+from pyspedas.projects.themis.state_tools.state import state
+from pyspedas.projects.themis.state_tools.slp import slp as load_slp
 
 
 def load_needed(trange_loaded,
@@ -167,6 +168,6 @@ def autoload_support(varname=None,
 
     # Perform the needed updates
     if do_slp:
-        pyspedas.projects.themis.slp(trange=trange_needed)
+        load_slp(trange=trange_needed)
     if do_state:
-        pyspedas.projects.themis.state(probe=probe, trange=trange_needed, get_support_data=True)
+        state(probe=probe, trange=trange_needed, get_support_data=True)

--- a/pyspedas/projects/themis/state_tools/autoload_support.py
+++ b/pyspedas/projects/themis/state_tools/autoload_support.py
@@ -87,7 +87,22 @@ def autoload_support(varname=None,
     # Set probe name (if needed)
     if spinaxis or spinmodel:
         if probe is None:
-            probe = varname[2]
+            if 'tha_' in varname:
+                probe='a'
+            elif 'thb_' in varname:
+                probe='b'
+            elif 'thc_' in varname:
+                probe='c'
+            elif 'thd_' in varname:
+                probe='d'
+            elif 'the_' in varname:
+                probe='e'
+            elif 'thf_' in varname:
+                probe='f'
+            else:
+                logging.error(f'Unable to determine probe letter from variable name {varname}')
+                return
+
 
     # Set time range (if needed)
     if trange is None:

--- a/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_tensor.py
+++ b/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_tensor.py
@@ -1,0 +1,80 @@
+import logging
+import numpy as np
+from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
+from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
+from pyspedas import tplot_wildcard_expand, get_data, replace_data
+def eclipse_spinmodel_corrections_tensor(tvars:str,
+                                         probe:str,
+                                         spin_based:bool=False,
+                                        ):
+    """
+    Use an eclipse spin model to correct a tensor quantity in DSL coordinates for errors in despinning during an eclipse.
+
+    Parameters
+    ----------
+    tvars: str or list[str]
+        A list of variables to correct. Wildcards are supported. All variables must be for the same probe.
+    probe: str
+        The probe for which support data should be loaded.  Valid values: ['a', 'b', 'c', 'd', 'e', 'f']
+    spin_based:bool
+        If True, apply a constant spin phase correction in addition to the time-varying corrections, to
+        correct for the disruption in the onboard spin sectoring algorithm during eclipses.  Use this for
+        spin-based data types like spin fits or moments.  Otherwise, only apply the time-varying corrections,
+        e.g. FGM, SCM, or EFI waveform data. The same value is used for all input variables. Default: False
+
+    Returns
+    -------
+    None
+    The variables are corrected in-place.
+    """
+
+    tvars_exp = tplot_wildcard_expand(tvars)
+    if len(tvars_exp) == 0:
+        logging.warning(f"No tplot variables found matching input {tvars}")
+        return
+    if probe not in ['a','b','c','d','e','f']:
+        logging.error(f"Invalid probe {probe}. Must be one of ['a', 'b', 'c', 'd', 'e', 'f']")
+
+    map3x3 = np.array([[0, 3, 4], [3, 1, 5], [4, 5, 2]])
+    mapt = np.array([0, 4, 8, 1, 2, 5])
+
+    for v in tvars_exp:
+        # The tensor-valued THEMIS data quantities don't have coordinate system metadata, so we'll
+        # assume DSL.
+
+        d=get_data(v)
+        t=d.times
+        autoload_support(v,probe=probe,spinmodel=True)
+        if spin_based:
+            sm = get_spinmodel(probe=probe, correction_level=2, quiet=True)
+        else:
+            sm = get_spinmodel(probe=probe, correction_level=1, quiet=True)
+        result=sm.interp_t(t, quiet=True)
+        delta_phi = result.eclipse_delta_phi
+        theta = delta_phi * np.pi/180.0
+        new_data=np.zeros(d.y.shape,dtype=d.y.dtype)
+        cs = np.cos(theta)
+        sn = np.sin(theta)
+
+        # Looping here is not as efficient as it could be, but probably more understandable
+        for idx in range(0,len(t)):
+            tensor = d.y[idx,:]
+            # Convert the 6-element representation to a 3x3 matrix
+            matrix = tensor[map3x3]
+            # Define a rotation matrix for this value od delta_phi
+            rot = np.array([[cs[idx], sn[idx], 0.0], [-sn[idx], cs[idx], 0.0], [0.0, 0.0, 1.0]])
+
+            # Apply the rotation, tensor-style.  Python is row-major while IDL is column-major, so
+            # the conversion is slightly different.
+
+            # NumPy equivalent of:
+            #
+            # rot # (tens3x3 # transpose(rot))
+            matrix_rotated = rot.T @ matrix @ rot
+
+            # Replace the old value with the corrected value
+            new_data[idx,:] = matrix_rotated.reshape(-1)[mapt]
+
+        replace_data(v,new_data)
+
+

--- a/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_tensor.py
+++ b/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_tensor.py
@@ -44,6 +44,10 @@ def eclipse_spinmodel_corrections_tensor(tvars:str,
 
         d=get_data(v)
         t=d.times
+        if d.y.shape[1] != 6:
+            raise ValueError(f"Data array for variable {v} with shape {d.y.shape} is not a 6-element tensor")
+        elif d.y.shape[0] != len(t):
+            raise ValueError(f"Mismatched time ({t.shape}) and data {d.y.shape} arrays for variable {v}")
         autoload_support(v,probe=probe,spinmodel=True)
         if spin_based:
             sm = get_spinmodel(probe=probe, correction_level=2, quiet=True)

--- a/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_vector.py
+++ b/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_vector.py
@@ -42,6 +42,13 @@ def eclipse_spinmodel_corrections_vector(tvars:str,
 
     for v in tvars_exp:
         # The correction must be done in DSL coordinates
+        d=get_data(v)
+        t=d.times
+        if d.y.shape[1] != 3:
+            raise ValueError(f"Data array for variable {v} with shape {d.y.shape} is not a 3-element vector")
+        elif d.y.shape[0] != len(t):
+            raise ValueError(f"Mismatched time ({t.shape}) and data {d.y.shape} arrays for variable {v}")
+
         coords=get_coords(v)
         if coords is None:
             logging.warning(f"Input variable {v} has no coordinate system metadata, assuming DSL")

--- a/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_vector.py
+++ b/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_vector.py
@@ -2,7 +2,7 @@ import logging
 import numpy as np
 from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
 from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
-from pyspedas import tplot_wildcard_expand, get_data, store_data, replace_data, get_coords
+from pyspedas import tplot_wildcard_expand, get_data, store_data, replace_data, get_coords, set_coords
 from pyspedas import cotrans
 from pyspedas.projects.themis.cotrans.dsl2gse import dsl2gse
 
@@ -49,25 +49,42 @@ def eclipse_spinmodel_corrections_vector(tvars:str,
         elif d.y.shape[0] != len(t):
             raise ValueError(f"Mismatched time ({t.shape}) and data {d.y.shape} arrays for variable {v}")
 
+        # We might have to infer the coordinates from the variable name, and update the metadata before proceeding
         coords=get_coords(v)
         if coords is None:
-            logging.warning(f"Input variable {v} has no coordinate system metadata, assuming DSL")
-            coords_in='dsl'
-            dsl_var = v
-        else:
-            coords_in=coords.lower()
-            # Some of the L2 MOM variables have extra junk afterthe coordinate system ("DSL (Despun Spacecraft")
-            # If that's the case, we need to fix coords_in for this routine to work.
-            if 'dsl' in coords_in:
-                dsl_var = v
-                coords_in='dsl'
-            elif coords_in == 'gse':
-                dsl2gse(v, 'temp_dsl', probe=probe, isgsetodsl=True)
-                dsl_var = 'temp_dsl'
+            if '_dsl' in v:
+                logging.warning(f"Input variable {v} has no coordinate system metadata, inferring DSL from variable name")
+                set_coords(v,'dsl')
+            elif '_gse' in v:
+                logging.warning(f"Input variable {v} has no coordinate system metadata, inferring GSE from variable name")
+                set_coords(v,'gse')
+            elif '_gsm' in v:
+                logging.warning(f"Input variable {v} has no coordinate system metadata, inferring GSM from variable name")
+                set_coords(v,'gsm')
+            elif '_gei' in v:
+                logging.warning(f"Input variable {v} has no coordinate system metadata, inferring GEI from variable name")
+                set_coords(v,'gei')
+            elif '_sm' in v:
+                logging.warning(f"Input variable {v} has no coordinate system metadata, inferring SM from variable name")
+                set_coords(v,'sm')
             else:
-                cotrans(v,'temp_gse',coord_in=coords_in,coord_out='gse')
-                dsl2gse('temp_gse','temp_dsl',probe=probe, isgsetodsl=True)
-                dsl_var='temp_dsl'
+                logging.warning(f"Input variable {v} has no coordinate system metadata, unable to infer coordinates from variable name, assuming DSL")
+                set_coords(v,'dsl')
+
+        coords=get_coords(v)
+        coords_in=coords.lower()
+        # Some of the L2 MOM variables have extra junk after the coordinate system ("DSL (Despun Spacecraft")
+        # If that's the case, we need to fix coords_in for this routine to work.
+        if 'dsl' in coords_in:
+            dsl_var = v
+            coords_in='dsl'
+        elif coords_in == 'gse':
+            dsl2gse(v, 'temp_dsl', probe=probe, isgsetodsl=True)
+            dsl_var = 'temp_dsl'
+        else:
+            cotrans(v,'temp_gse',coord_in=coords_in,coord_out='gse')
+            dsl2gse('temp_gse','temp_dsl',probe=probe, isgsetodsl=True)
+            dsl_var='temp_dsl'
 
         d=get_data(dsl_var)
         t=d.times

--- a/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_vector.py
+++ b/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_vector.py
@@ -44,7 +44,7 @@ def eclipse_spinmodel_corrections_vector(tvars:str,
         # The correction must be done in DSL coordinates
         d=get_data(v)
         t=d.times
-        if d.y.shape[1] != 3:
+        if (len(d.y.shape) <= 1) or d.y.shape[1] != 3:
             raise ValueError(f"Data array for variable {v} with shape {d.y.shape} is not a 3-element vector")
         elif d.y.shape[0] != len(t):
             raise ValueError(f"Mismatched time ({t.shape}) and data {d.y.shape} arrays for variable {v}")

--- a/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_vector.py
+++ b/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_vector.py
@@ -52,11 +52,11 @@ def eclipse_spinmodel_corrections_vector(tvars:str,
             if coords_in == 'dsl':
                 dsl_var = v
             elif coords_in == 'gse':
-                dsl2gse(v, 'temp_dsl', isgsetodsl=True)
+                dsl2gse(v, 'temp_dsl', probe=probe, isgsetodsl=True)
                 dsl_var = 'temp_dsl'
             else:
                 cotrans(v,'temp_gse',coord_in=coords_in,coord_out='gse')
-                dsl2gse('temp_gse','temp_dsl',isgsetodsl=True)
+                dsl2gse('temp_gse','temp_dsl',probe=probe, isgsetodsl=True)
                 dsl_var='temp_dsl'
 
         d=get_data(dsl_var)
@@ -85,8 +85,8 @@ def eclipse_spinmodel_corrections_vector(tvars:str,
         if coords_in == 'dsl':
             pass;
         elif coords_in == 'gse':
-            dsl2gse(dsl_var,v,isgsetodsl=False)
+            dsl2gse(dsl_var,v,probe=probe,isgsetodsl=False)
         else:
-            dsl2gse(dsl_var,'temp_gse', isgsetodsl=False)
+            dsl2gse(dsl_var,'temp_gse',probe=probe, isgsetodsl=False)
             cotrans('temp_gse',v,coord_out=coords_in)
 

--- a/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_vector.py
+++ b/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_vector.py
@@ -1,0 +1,92 @@
+import logging
+import numpy as np
+from pyspedas.projects.themis.state_tools.autoload_support import autoload_support
+from pyspedas.projects.themis.state_tools.spinmodel.spinmodel import get_spinmodel
+from pyspedas import tplot_wildcard_expand, get_data, store_data, replace_data, get_coords
+from pyspedas import cotrans
+from pyspedas.projects.themis.cotrans.dsl2gse import dsl2gse
+
+def eclipse_spinmodel_corrections_vector(tvars:str,
+                                         probe:str,
+                                         spin_based:bool=False,
+                                        ):
+    """
+    Use an eclipse spin model to correct a vector quantity in DSL coordinates for errors in despinning during an eclipse.
+
+
+
+    Parameters
+    ----------
+    tvars: str or list[str]
+        A list of variables to correct. Wildcards are supported. All variables must be for the same probe.
+    probe: str
+        The probe for which support data should be loaded.  Valid values: ['a', 'b', 'c', 'd', 'e', 'f']
+    spin_based:bool
+        If True, apply a constant spin phase correction in addition to the time-varying corrections, to
+        correct for the disruption in the onboard spin sectoring algorithm during eclipses.  Use this for
+        spin-based data types like spin fits or moments.  Otherwise, only apply the time-varying corrections,
+        e.g. FGM, SCM, or EFI waveform data. The same value is used for all input variables. Default: False
+
+    Returns
+    -------
+    None
+    The variables are corrected in-place.
+    """
+
+    tvars_exp = tplot_wildcard_expand(tvars)
+    if len(tvars_exp) == 0:
+        logging.warning(f"No tplot variables found matching input {tvars}")
+        return
+    if probe not in ['a','b','c','d','e','f']:
+        logging.error(f"Invalid probe {probe}. Must be one of ['a', 'b', 'c', 'd', 'e', 'f']")
+
+    for v in tvars_exp:
+        # The correction must be done in DSL coordinates
+        coords=get_coords(v)
+        if coords is None:
+            logging.warning(f"Input variable {v} has no coordinate system metadata, assuming DSL")
+            coords_in='dsl'
+            dsl_var = v
+        else:
+            coords_in=coords.lower()
+            if coords_in == 'dsl':
+                dsl_var = v
+            elif coords_in == 'gse':
+                dsl2gse(v, 'temp_dsl', isgsetodsl=True)
+                dsl_var = 'temp_dsl'
+            else:
+                cotrans(v,'temp_gse',coord_in=coords_in,coord_out='gse')
+                dsl2gse('temp_gse','temp_dsl',isgsetodsl=True)
+                dsl_var='temp_dsl'
+
+        d=get_data(dsl_var)
+        t=d.times
+        x = d.y[:,0]
+        y = d.y[:,1]
+        autoload_support(v,probe=probe,spinmodel=True)
+        if spin_based:
+            sm = get_spinmodel(probe=probe, correction_level=2, quiet=True)
+        else:
+            sm = get_spinmodel(probe=probe, correction_level=1, quiet=True)
+        result=sm.interp_t(t, quiet=True)
+        delta_phi = result.eclipse_delta_phi
+        theta = delta_phi * np.pi/180.0
+        cs = np.cos(theta)
+        sn = np.sin(theta)
+        xp = x*cs - y*sn
+        yp = x*sn + y*cs
+        new_data=np.zeros(d.y.shape,dtype=d.y.dtype)
+        new_data[:,0] = xp
+        new_data[:,1] = yp
+        new_data[:,2] = d.y[:,2]
+        replace_data(dsl_var,new_data)
+
+        # Now convert back to the original coordinate system
+        if coords_in == 'dsl':
+            pass;
+        elif coords_in == 'gse':
+            dsl2gse(dsl_var,v,isgsetodsl=False)
+        else:
+            dsl2gse(dsl_var,'temp_gse', isgsetodsl=False)
+            cotrans('temp_gse',v,coord_out=coords_in)
+

--- a/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_vector.py
+++ b/pyspedas/projects/themis/state_tools/spinmodel/eclipse_spinmodel_corrections_vector.py
@@ -49,8 +49,11 @@ def eclipse_spinmodel_corrections_vector(tvars:str,
             dsl_var = v
         else:
             coords_in=coords.lower()
-            if coords_in == 'dsl':
+            # Some of the L2 MOM variables have extra junk afterthe coordinate system ("DSL (Despun Spacecraft")
+            # If that's the case, we need to fix coords_in for this routine to work.
+            if 'dsl' in coords_in:
                 dsl_var = v
+                coords_in='dsl'
             elif coords_in == 'gse':
                 dsl2gse(v, 'temp_dsl', probe=probe, isgsetodsl=True)
                 dsl_var = 'temp_dsl'

--- a/pyspedas/projects/themis/state_tools/spinmodel/spinmodel.py
+++ b/pyspedas/projects/themis/state_tools/spinmodel/spinmodel.py
@@ -169,9 +169,20 @@ class Spinmodel:
         bad_idx = np.flatnonzero(mismatch)
         c = bad_idx.size
         if c != 0:
-            logging.warning('Indices don''t match up: time gaps or overlaps detected. Mismatched indices:')
+            # What are the time discrepancies between the segment start/end times involved?
+            dt1 = self.seg_t2[idx1[bad_idx] - 1]
+            dt2 = self.seg_times[idx1[bad_idx]]
+            dt_mismatch = dt2 - dt1
+            tolerance = 1.0e-05
+            logging.warning('spinmodel.findseg_t: Indices don''t match up: time gaps or overlaps detected. Mismatched indices:')
             logging.warning(bad_idx)
-            raise ValueError
+            logging.warning(f"Delta-t of mismatched segment start/end times: {dt_mismatch}")
+            max_abs_mismatch = np.max(np.abs(dt_mismatch))
+            if max_abs_mismatch > tolerance:
+                raise ValueError(f"Segment start/end time mismatch exceeds tolerance of {tolerance}. Please report this error to the PySPEDAS developers.")
+            else:
+                logging.warning(f"Maximum absolute mismatch {max_abs_mismatch} is within acceptable tolerance {tolerance}, continuing...")
+                return idx1_clip
         else:
             return idx1_clip
 

--- a/pyspedas/projects/themis/state_tools/spinmodel/spinmodel.py
+++ b/pyspedas/projects/themis/state_tools/spinmodel/spinmodel.py
@@ -569,6 +569,37 @@ class Spinmodel:
         return start_times, end_times
 
     def eclipse_correction_status(self):
+        """
+            Return the start time, end time, status flags, and human readable status strings
+            describing each eclipse found in the spinmodel object.
+
+        Returns
+        -------
+        tuple
+
+        Examples
+        ---------
+
+        >>> from pyspedas.projects.themis import state, get_spinmodel
+        >>> from pyspedas import time_string
+        >>>
+        >>> trange=['2026-01-01','2026-01-03']
+        >>> probe='b'
+        >>> state(probe=probe,trange=trange,get_support_data=True)
+        >>> sm_spinfit=get_spinmodel(probe=probe,correction_level=2,quiet=True)
+        >>> start_times, end_times, flags, flag_strings = sm_spinfit.eclipse_correction_status()
+        >>> n = len(start_times)
+        >>> if n > 0:
+        >>>     print(f"Eclipse correction status for probe {probe}:")
+        >>>     for i in range(n):
+        >>>         print(f"Eclipse {i+1} of {n}: start: {time_string(start_times[i])}  end: {time_string(end_times[i])} status: {flag_strings[i]}")
+        >>>
+        Eclipse correction status for probe b:
+        Eclipse 1 of 2: start: 2026-01-01 16:35:56.538661  end: 2026-01-01 17:18:33.575686 status: in shadow, partially corrected (field waveforms corrected; particle data and EFI or FGM spin fits will have uncorrected spin phase offsets)
+        Eclipse 2 of 2: start: 2026-01-02 17:17:50.628083  end: 2026-01-02 18:00:23.389013 status: in shadow, fully corrected
+
+
+        """
         start_times, end_times = self.get_eclipse_times()
         ntimes = len(start_times)
         flags = []

--- a/pyspedas/projects/themis/state_tools/spinmodel/spinmodel.py
+++ b/pyspedas/projects/themis/state_tools/spinmodel/spinmodel.py
@@ -177,7 +177,8 @@ class Spinmodel:
 
     def interp_t(self,
                  t: np.ndarray,
-                 use_spinphase_correction: bool = True) -> SpinmodelInterpTResult:
+                 use_spinphase_correction: bool = True,
+                 quiet: bool = False) -> SpinmodelInterpTResult:
         """ Interpolate the spin model to a set of input times, and return an object holding the results.
 
         This is the workhorse routine for accessing the spin model. Clients will specify a set of input times (e.g.
@@ -197,6 +198,7 @@ class Spinmodel:
             t (ndarray(dtype=float): Input times
             use_spinphase_correction (Boolean): Flag (defaults to True) specifying whether V03 state CDF corrections
                 should be applied to the interpolation output.
+            quiet (boolean): If True, suppress routine progress messages
 
         Returns:
             SpinmodelInterpTResult object containing the interpolated outputs (spinphase, spincount, spin period,
@@ -316,7 +318,8 @@ class Spinmodel:
             spincount[idx3] = spincount[idx3] + my_seg_c1[idx3]
 
         if use_spinphase_correction:
-            logging.info("applying spinphase correction")
+            if not quiet:
+                logging.info("applying spinphase correction")
             interp_correction = np.interp(t, self.spin_corr_times, self.spin_corr_vals)
             spinphase -= interp_correction
             cond = spinphase > 360.0
@@ -553,6 +556,30 @@ class Spinmodel:
                 end_times[-1]=self.seg_t2[i]
 
         return start_times, end_times
+
+    def eclipse_correction_status(self):
+        start_times, end_times = self.get_eclipse_times()
+        ntimes = len(start_times)
+        flags = []
+        flag_strings = []
+        if ntimes > 0:
+            for i in range(ntimes):
+                mid_time = start_times[i] + (end_times[i]-start_times[i])/2.0
+                result = self.interp_t(np.array([mid_time]), use_spinphase_correction=True, quiet=True)
+                flag = result.segflags
+                flags.append(flag)
+                if flag==0:
+                    flag_strings.append("in sunlight")
+                elif flag==1:
+                    flag_strings.append("in shadow, no corrections available")
+                elif flag==3:
+                    flag_strings.append("in shadow, partially corrected (field waveforms corrected; particle data and EFI or FGM spin fits will have uncorrected spin phase offsets)")
+                elif flag==7:
+                    flag_strings.append("in shadow, fully corrected")
+                else:
+                    flag_strings.append(f"unrecognized segflags value {flag}")
+        return start_times, end_times, flags, flag_strings
+
 
 
     def __init__(self,

--- a/pyspedas/projects/themis/tests/test_themis.py
+++ b/pyspedas/projects/themis/tests/test_themis.py
@@ -128,6 +128,13 @@ class LoadTestCases(unittest.TestCase):
         pyspedas.projects.themis.esa(varnames=['thc_peif_density'])
         self.assertTrue(data_exists('thc_peif_density'))
 
+    def test_load_esa_eclipse(self):
+        """Load ESA."""
+        trange=['2026-01-01','2026-01-03']
+        probe='b'
+        pyspedas.projects.themis.esa(probe=probe, trange=trange, level='l2', apply_eclipse_corrections=True)
+        self.assertTrue(data_exists('thb_peif_mftens'))
+
     def test_load_fft_data(self):
         """Load FFT."""
         pyspedas.projects.themis.fft(varnames=['thc_ffp_16_edc34'])

--- a/pyspedas/projects/themis/tests/test_themis.py
+++ b/pyspedas/projects/themis/tests/test_themis.py
@@ -104,6 +104,13 @@ class LoadTestCases(unittest.TestCase):
         pyspedas.projects.themis.fgm(varnames=['thc_fgs_btotal'])
         self.assertTrue(data_exists('thc_fgs_btotal'))
 
+    def test_load_fgm_data_eclipse(self):
+        """Load FGM."""
+        trange=['2026-01-01','2026-01-03']
+        probe='b'
+        pyspedas.projects.themis.fgm(probe=probe, trange=trange, level='l2', apply_eclipse_corrections=True)
+        self.assertTrue(data_exists('thb_fgs_dsl'))
+
     def test_load_fit_data(self):
         """Load FIT."""
         pyspedas.projects.themis.fit(varnames=['thc_fgs_gse'])

--- a/pyspedas/projects/themis/tests/test_themis.py
+++ b/pyspedas/projects/themis/tests/test_themis.py
@@ -116,6 +116,13 @@ class LoadTestCases(unittest.TestCase):
         pyspedas.projects.themis.fit(varnames=['thc_fgs_gse'])
         self.assertTrue(data_exists('thc_fgs_gse'))
 
+    def test_load_fit_eclipse(self):
+        """Load FIT."""
+        trange=['2026-01-01','2026-01-03']
+        probe='b'
+        pyspedas.projects.themis.fit(probe=probe, trange=trange, level='l2', apply_eclipse_corrections=True)
+        self.assertTrue(data_exists('thb_fgs_gse'))
+
     def test_load_esa_data(self):
         """Load ESA."""
         pyspedas.projects.themis.esa(varnames=['thc_peif_density'])

--- a/pyspedas/projects/themis/tests/test_themis.py
+++ b/pyspedas/projects/themis/tests/test_themis.py
@@ -99,6 +99,14 @@ class LoadTestCases(unittest.TestCase):
         pyspedas.projects.themis.sst(varnames=['thc_psif_en_eflux'])
         self.assertTrue(data_exists('thc_psif_en_eflux'))
 
+    def test_load_sst_eclipse(self):
+        """Load SST."""
+        trange=['2026-01-01','2026-01-03']
+        probe='b'
+
+        pyspedas.projects.themis.sst(probe=probe, trange=trange, level='l2', apply_eclipse_corrections=True)
+        self.assertTrue(data_exists('thb_psif_mftens'))
+
     def test_load_fgm_data(self):
         """Load FGM."""
         pyspedas.projects.themis.fgm(varnames=['thc_fgs_btotal'])

--- a/pyspedas/projects/themis/tests/test_themis.py
+++ b/pyspedas/projects/themis/tests/test_themis.py
@@ -148,6 +148,13 @@ class LoadTestCases(unittest.TestCase):
         pyspedas.projects.themis.mom(varnames=['thc_peim_density'])
         self.assertTrue(data_exists('thc_peim_density'))
 
+    def test_load_mom_eclipse(self):
+        """Load MOM."""
+        trange=['2026-01-01','2026-01-03']
+        probe='b'
+        pyspedas.projects.themis.mom(probe='b', trange=trange, level='l2', apply_eclipse_corrections=True)
+        self.assertTrue(data_exists('thb_peim_mftens'))
+
     def test_load_gmom_data(self):
         """Load GMOM."""
         pyspedas.projects.themis.gmom(trange=['2020-01-01', '2020-01-01'],

--- a/pyspedas/projects/themis/tests/test_themis.py
+++ b/pyspedas/projects/themis/tests/test_themis.py
@@ -159,6 +159,13 @@ class LoadTestCases(unittest.TestCase):
         pyspedas.projects.themis.scm(varnames=['thc_scf_btotal'])
         self.assertTrue(data_exists('thc_scf_btotal'))
 
+    def test_load_scm_eclipse(self):
+        """Load SCM."""
+        trange=['2026-01-01','2026-01-03']
+        probe='b'
+        pyspedas.projects.themis.scm(probe=probe,trange=trange,level='l2',apply_eclipse_corrections=True)
+        self.assertTrue(data_exists('thb_scf_gse'))
+
     def test_load_scm_l1_data(self):
         """Load L1 SCM."""
         pyspedas.projects.themis.scm(level='l1', varnames=['thc_scf'])

--- a/pyspedas/projects/themis/tests/test_themis.py
+++ b/pyspedas/projects/themis/tests/test_themis.py
@@ -191,6 +191,13 @@ class LoadTestCases(unittest.TestCase):
         self.assertTrue(data_exists('thc_eff_e12_efs'))
         self.assertFalse('thc_efw_gse' in vars)
 
+    def test_load_efi_eclipse(self):
+        """Load EFI."""
+        trange=['2026-01-01','2026-01-03']
+        probe='b'
+        vars = pyspedas.projects.themis.efi(probe=probe,trange=trange,level='l2',apply_eclipse_corrections=True)
+        self.assertTrue(data_exists('thb_eff_e12_efs'))
+
     def test_load_l2_efw_data(self):
         """Load EFI L2 wave burst data"""
         vars = pyspedas.projects.themis.efi(trange=['2017-01-01','2017-01-02'], probe='a',time_clip=True, datatype='efw')

--- a/pyspedas/projects/themis/tests/test_themis.py
+++ b/pyspedas/projects/themis/tests/test_themis.py
@@ -161,6 +161,13 @@ class LoadTestCases(unittest.TestCase):
                              varnames=['thc_ptiff_density'])
         self.assertTrue(data_exists('thc_ptiff_density'))
 
+    def test_load_gmom_eclipse(self):
+        """Load GMOM."""
+        trange=['2026-01-01','2026-01-03']
+        probe='b'
+        pyspedas.projects.themis.gmom(probe='b', trange=trange, level='l2', apply_eclipse_corrections=True)
+        self.assertTrue(data_exists('thb_ptiff_velocity_gse'))
+
     def test_load_scm_data(self):
         """Load SCM."""
         pyspedas.projects.themis.scm(varnames=['thc_scf_btotal'])

--- a/pyspedas/projects/themis/tests/test_themis_spinmodel.py
+++ b/pyspedas/projects/themis/tests/test_themis_spinmodel.py
@@ -1,8 +1,9 @@
 """ Tests of spinmodel construction and interpolation """
 import unittest
 from numpy.testing import assert_array_almost_equal_nulp, assert_array_max_ulp, assert_allclose
-from pyspedas.tplot_tools import get_data, store_data, time_string, del_data, cdf_to_tplot
+from pyspedas.tplot_tools import get_data, store_data, time_string, del_data, cdf_to_tplot, tplot_copy, tnames
 from pyspedas.projects.themis import state, get_spinmodel
+import logging
 
 
 
@@ -49,11 +50,13 @@ class SpinmodelDataValidation(unittest.TestCase):
         # Load validation variables from the test file
         del_data('*')
         filename = datafile[0]
+        #filename='/tmp/spinmodel_python_test_data.cdf'
         cdf_to_tplot(filename)
         # tplot_restore(filename)
         t_dummy, trange = get_data('parm_trange')
         t_dummy, probe_idx = get_data('parm_probe')
         t_dummy, correction_level = get_data('parm_correction_level')
+
         #print(trange)
         #print(time_string(trange))
         #print(probe_idx)
@@ -61,6 +64,19 @@ class SpinmodelDataValidation(unittest.TestCase):
         probes = ['a', 'b', 'c', 'd', 'e']
         int_corr_level = int(correction_level[0])
         probe = probes[int_idx]
+        tplot_copy('thb_fgs_dsl',new_name='idl_thb_fgs_dsl')
+        tplot_copy('thb_fgl_dsl',new_name='idl_thb_fgl_dsl')
+        tplot_copy('thb_fgs_dsl_corrected',new_name='idl_thb_fgs_dsl_corrected')
+        tplot_copy('thb_fgl_dsl_corrected',new_name='idl_thb_fgl_dsl_corrected')
+        tplot_copy('thb_peem_ptens',new_name='idl_thb_peem_ptens')
+        tplot_copy('thb_peem_mftens',new_name='idl_thb_peem_mftens')
+        tplot_copy('thb_peim_ptens',new_name='idl_thb_peim_ptens')
+        tplot_copy('thb_peim_mftens',new_name='idl_thb_peim_mftens')
+        tplot_copy('thb_peem_ptens_corrected',new_name='idl_thb_peem_ptens_corrected')
+        tplot_copy('thb_peem_mftens_corrected',new_name='idl_thb_peem_mftens_corrected')
+        tplot_copy('thb_peim_ptens_corrected',new_name='idl_thb_peim_ptens_corrected')
+        tplot_copy('thb_peim_mftens_corrected',new_name='idl_thb_peim_mftens_corrected')
+
         #print(probe)
         #print(int_corr_level)
         thm_data = state(trange=trange, probe=probe, get_support_data=True)
@@ -173,6 +189,67 @@ class SpinmodelDataValidation(unittest.TestCase):
         start_times,end_times=self.model.get_eclipse_times()
         for i in range(len(start_times)):
             print(time_string(start_times[i]),time_string(end_times[i]))
+
+    def test_eclipse_correction_fgs(self):
+        from pyspedas.projects.themis import fgm
+        from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_vector import eclipse_spinmodel_corrections_vector
+        from pyspedas import tnames
+        from pyspedas import tplot
+        trange=['2026-01-01','2026-01-03']
+        #fgm(probe='b',trange=trange)
+        tplot_copy('idl_thb_fgs_dsl', new_name='py_thb_fgs_dsl')
+        tplot_copy('idl_thb_fgl_dsl', new_name='py_thb_fgl_dsl')
+        tnames('*fg*')
+        eclipse_spinmodel_corrections_vector('py_thb_fgs_dsl',probe='b',spin_based=True)
+        eclipse_spinmodel_corrections_vector('py_thb_fgl_dsl',probe='b',spin_based=False)
+        py_fgl_corr = get_data('py_thb_fgl_dsl')
+        py_fgs_corr = get_data('py_thb_fgs_dsl')
+        idl_fgl_corr = get_data('idl_thb_fgl_dsl_corrected')
+        idl_fgs_corr = get_data('idl_thb_fgs_dsl_corrected')
+        fgl_diff = py_fgl_corr.y - idl_fgl_corr.y
+        fgs_diff = py_fgs_corr.y - idl_fgs_corr.y
+        store_data('fgs_diff',data={'x':py_fgs_corr.times,'y':fgs_diff})
+        store_data('fgl_diff',data={'x':py_fgl_corr.times,'y':fgl_diff})
+        # tplot('idl_thb_fgs_dsl idl_thb_fgs_dsl_corrected py_thb_fgs_dsl fgs_diff '+
+        #       'idl_thb_fgl_dsl idl_thb_fgl_dsl_corrected py_thb_fgl_dsl fgl_diff')
+        assert_allclose(py_fgl_corr.y, idl_fgl_corr.y, atol=1.0e-04, rtol=1.0e-05)
+        assert_allclose(py_fgs_corr.y, idl_fgs_corr.y, atol=1.0e-04, rtol=1.0e-05)
+
+    def test_eclipse_correction_mom_tensors(self):
+        from pyspedas.projects.themis.state_tools.spinmodel.eclipse_spinmodel_corrections_tensor import eclipse_spinmodel_corrections_tensor
+        from pyspedas import tnames
+        from pyspedas import tplot
+        from pyspedas import subtract
+        to_correct = ['peim_ptens','peim_mftens', 'peem_ptens','peem_mftens']
+        pre_correct = []
+        post_correct = []
+        vars_to_plot = []
+        for v in to_correct:
+            oldvar = 'idl_thb_'+v
+            newvar = 'py_thb_'+v+'_corrected'
+            cmp_var = oldvar + '_corrected'
+            diff_var = 'diff_' + v
+            pre_correct.append(oldvar)
+            post_correct.append(newvar)
+            vars_to_plot.append(oldvar)
+            vars_to_plot.append(newvar)
+            tplot_copy(oldvar,newvar)
+            eclipse_spinmodel_corrections_tensor(newvar, probe="b", spin_based=True)
+            idl=get_data(cmp_var)
+            py=get_data(newvar)
+            diff = idl.y - py.y
+            store_data(diff_var,data={'x':idl.times, 'y':diff})
+            vars_to_plot.append(diff_var)
+            logging.info(f"Comparing IDL and Python results for {v} ")
+            assert_allclose(py.y, idl.y, atol=.001, rtol=1.0e-2)
+        # tplot(vars_to_plot)
+        sm = get_spinmodel(probe='b',correction_level=2,quiet=False)
+        ecl_start,ecl_end,flags, flag_strings = sm.eclipse_correction_status()
+        ntimes = len(ecl_start)
+        if ntimes > 0:
+            for i in range(ntimes):
+                logging.info(f"Eclipse {i+1} of {ntimes}: start {time_string(ecl_start[i])} end {time_string(ecl_end[i])}  status: {flag_strings[i]}")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add routines to perform THEMIS eclipse spin model corrections on vector and tensor tplot variables.  
Add boolean apply_eclipse_corrections flag to relevant THEMIS load routines.
Update docstrings and readthedocs with information about spin models and eclipse corrections.
Add a slight tolerance to consistency check for spin model segment start/stop times.