### PR TITLE
1408 responding to http 429 too many requests responses from maven

### DIFF
--- a/.github/workflows/full_coverage.yml
+++ b/.github/workflows/full_coverage.yml
@@ -265,9 +265,9 @@ jobs:
               echo "Disk usage after cleanup:"
               df -h
 
-          - shard: erg_maven_etc
+          - shard: erg_etc
             shard_script: |
-              # This set of tests exercises mostly MAVEN and ERG routines
+              # This set of tests exercises mostly ERG routines
               # This is good to have in case any tests access MMS data
               echo "Setting up credentials for MMS tests"
               coverage run -a -m pyspedas.projects.mms.tests.test_mms_setup
@@ -304,10 +304,6 @@ jobs:
               coverage run -a -m pyspedas.mth5.tests.test_load_fdsn
               echo Starting akebono tests at `date`
               coverage run -a -m pyspedas.projects.akebono.tests.test_akebono
-              #echo Starting maven S3 tests at `date`
-              #coverage run -a -m pyspedas.projects.maven.tests.test_maven_uri
-              echo Starting maven tests at `date`
-              coverage run -a -m pyspedas.projects.maven.tests.test_maven
               echo Starting VIRES client tests at `date`
               coverage run -a -m pyspedas.vires.tests.test_vires
               echo Starting secs tests at `date`
@@ -316,7 +312,7 @@ jobs:
               coverage run -a -m pyspedas.particles.tests.test_particles
               echo "========================================================="
               # Show the free disk space on this filesystem      
-              echo "Disk usage after ERG,MAVEN,etc test group:"
+              echo "Disk usage after ERG,etc test group:"
               df -h
               du -sh "$MMS_DATA_DIR" 2>/dev/null || true
               echo "Cleaning downloads"
@@ -324,6 +320,26 @@ jobs:
               rm -rf "$SPEDAS_DATA_DIR"/*
               
               # Show the free disk space on this filesystem      
+              echo "Disk usage after cleanup:"
+              df -h
+
+          - shard: maven
+            shard_script: |
+              # This set of tests exercises MAVEN routines
+              echo Starting maven S3 tests at `date`
+              coverage run -a -m pyspedas.projects.maven.tests.test_maven_uri
+              echo Starting maven tests at `date`
+              coverage run -a -m pyspedas.projects.maven.tests.test_maven
+              echo "========================================================="
+              # Show the free disk space on this filesystem
+              echo "Disk usage after MAVEN test group:"
+              df -h
+              du -sh "$DATA_ROOT"/* 2>/dev/null || true
+              echo "Cleaning MAVEN downloads"
+              rm -rf "$DATA_ROOT"/*
+              rm -rf "$SPEDAS_DATA_DIR"/*
+
+              # Show the free disk space on this filesystem
               echo "Disk usage after cleanup:"
               df -h
 

--- a/.github/workflows/full_coverage.yml
+++ b/.github/workflows/full_coverage.yml
@@ -326,8 +326,8 @@ jobs:
           - shard: maven
             shard_script: |
               # This set of tests exercises MAVEN routines
-              echo Starting maven S3 tests at `date`
-              coverage run -a -m pyspedas.projects.maven.tests.test_maven_uri
+              # echo Starting maven S3 tests at `date`
+              # coverage run -a -m pyspedas.projects.maven.tests.test_maven_uri
               echo Starting maven tests at `date`
               coverage run -a -m pyspedas.projects.maven.tests.test_maven
               echo "========================================================="

--- a/pyspedas/projects/maven/download_files_utilities.py
+++ b/pyspedas/projects/maven/download_files_utilities.py
@@ -61,9 +61,6 @@ def get_file_from_site(filename, public, data_dir):
     Returns:
         None
     """
-    import os
-    import urllib
-
     public_url = (
         "https://lasp.colorado.edu/maven/sdc/public/files/api/v1/search/science/fn_metadata/download"
         + "?file="
@@ -75,35 +72,25 @@ def get_file_from_site(filename, public, data_dir):
         + filename
     )
 
+    url = public_url if public else private_url
+    logging.debug("get_file_from_site making request to URL: %s", url)
+
+    download_options = {
+        "remote_file": url,
+        "local_path": data_dir,
+        "local_file": filename,
+        "no_wildcards": True,
+        "force_download": True,
+    }
     if not public:
-        uname = CONFIG["maven_username"]
-        pword = CONFIG["maven_password"]
-        username = uname
-        password = pword
-        p = urllib.request.HTTPPasswordMgrWithDefaultRealm()
-        p.add_password(None, private_url, username, password)
-        handler = urllib.request.HTTPBasicAuthHandler(p)
-        opener = urllib.request.build_opener(handler)
-        urllib.request.install_opener(opener)
-        logging.debug("get_file_from_site making request to private url: %s", private_url)
-        page = urllib.request.urlopen(private_url)
-        logging.debug("get_file_from_site finished request to private url: %s", private_url)
-    else:
-        logging.debug("get_file_from_site making request to public url: %s", public_url)
-        page = urllib.request.urlopen(public_url)
-        logging.debug("get_file_from_site finished request to public url: %s", public_url)
+        download_options.update(
+            username=CONFIG["maven_username"],
+            password=CONFIG["maven_password"],
+            basic_auth=True,
+        )
 
-    # Cloud Awareness: write page contents to URI
-    if is_fsspec_uri(data_dir):
-        protocol, path = data_dir.split("://")
-        fs = fsspec.filesystem(protocol)
-
-        fo = fs.open("/".join([data_dir, filename]), "wb")
-    else:
-        fo = open(os.path.join(data_dir, filename), "wb")
-
-    with fo as code:
-        code.write(page.read())
+    download(**download_options)
+    logging.debug("get_file_from_site finished request to URL: %s", url)
 
     return
 

--- a/pyspedas/projects/maven/download_files_utilities.py
+++ b/pyspedas/projects/maven/download_files_utilities.py
@@ -2,7 +2,7 @@ import logging
 from .file_regex import maven_kp_l2_regex
 from .config import CONFIG
 
-from pyspedas.utilities.download import is_fsspec_uri
+from pyspedas.utilities.download import download, is_fsspec_uri
 import fsspec
 
 def get_filenames(query, public):
@@ -17,10 +17,8 @@ def get_filenames(query, public):
         str: The file names retrieved as a string.
 
     Raises:
-        urllib.error.URLError: If there is an error in accessing the URL.
+        requests.exceptions.RequestException: If there is an error accessing the URL.
     """
-
-    import urllib
 
     public_url = (
         "https://lasp.colorado.edu/maven/sdc/public/files/api/v1/search/science/fn_metadata/file_names"
@@ -32,26 +30,23 @@ def get_filenames(query, public):
         + "?"
         + query
     )
+    url = public_url if public else private_url
+    logging.debug("get_filenames() making request to URL: %s", url)
+
+    download_options = {
+        "remote_file": url,
+        "return_text": True,
+    }
     if not public:
-        uname = CONFIG["maven_username"]
-        pword = CONFIG["maven_password"]
-        username = uname
-        password = pword
-        p = urllib.request.HTTPPasswordMgrWithDefaultRealm()
-        p.add_password(None, private_url, username, password)
-        handler = urllib.request.HTTPBasicAuthHandler(p)
-        opener = urllib.request.build_opener(handler)
-        urllib.request.install_opener(opener)
-        logging.debug("get_filenames() making request to private URL: %s", private_url)
-        page = urllib.request.urlopen(private_url)
-        logging.debug("get_filenames() finished request to private URL: %s", private_url)
+        download_options.update(
+            username=CONFIG["maven_username"],
+            password=CONFIG["maven_password"],
+            basic_auth=True,
+        )
 
-    else:
-        logging.debug("get_filenames() making request to public URL: %s", public_url)
-        page = urllib.request.urlopen(public_url)
-        logging.debug("get_filenames() finished request to public URL: %s", public_url)
-
-    return page.read().decode("utf-8")
+    response_text = download(**download_options)
+    logging.debug("get_filenames() finished request to URL: %s", url)
+    return response_text
 
 
 def get_file_from_site(filename, public, data_dir):

--- a/pyspedas/projects/maven/tests/test_maven.py
+++ b/pyspedas/projects/maven/tests/test_maven.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest.mock import patch
 from pyspedas.tplot_tools import data_exists, tplot_names, del_data
 from pyspedas.projects import maven
 from pyspedas.projects.maven.download_files_utilities import get_orbit_files, merge_orbit_files, get_file_from_site
@@ -44,6 +45,50 @@ class OrbitTestCases(unittest.TestCase):
             CONFIG["local_data_dir"], "orbitfiles", "merged_maven_orbits.orb"
         )
         self.assertTrue(os.path.exists(orbfilepath))
+
+
+class DownloadFileTestCases(unittest.TestCase):
+    @patch("pyspedas.projects.maven.download_files_utilities.download")
+    def test_get_file_from_public_site(self, mock_download):
+        filename = "mvn_mag_l2_20200101_v01_r01.cdf"
+
+        get_file_from_site(filename, public=True, data_dir="maven_data")
+
+        mock_download.assert_called_once_with(
+            remote_file=(
+                "https://lasp.colorado.edu/maven/sdc/public/files/api/v1/"
+                "search/science/fn_metadata/download?file=" + filename
+            ),
+            local_path="maven_data",
+            local_file=filename,
+            no_wildcards=True,
+            force_download=True,
+        )
+
+    @patch("pyspedas.projects.maven.download_files_utilities.download")
+    def test_get_file_from_private_site(self, mock_download):
+        filename = "mvn_mag_l2_20200101_v01_r01.cdf"
+        credentials = {
+            "maven_username": "test-user",
+            "maven_password": "test-password",
+        }
+
+        with patch.dict(CONFIG, credentials):
+            get_file_from_site(filename, public=False, data_dir="maven_data")
+
+        mock_download.assert_called_once_with(
+            remote_file=(
+                "https://lasp.colorado.edu/maven/sdc/service/files/api/v1/"
+                "search/science/fn_metadata/download?file=" + filename
+            ),
+            local_path="maven_data",
+            local_file=filename,
+            no_wildcards=True,
+            force_download=True,
+            username="test-user",
+            password="test-password",
+            basic_auth=True,
+        )
 
 
 class LoadTestCases(unittest.TestCase):

--- a/pyspedas/utilities/download.py
+++ b/pyspedas/utilities/download.py
@@ -20,6 +20,42 @@ from cdflib import CDF
 from time import sleep
 from .rate_connection_quality import rate_connection_quality
 
+
+class LoggingRetry(Retry):
+    """Log HTTP status retries while preserving urllib3 retry behavior."""
+
+    def increment(
+        self,
+        method=None,
+        url=None,
+        response=None,
+        error=None,
+        _pool=None,
+        _stacktrace=None,
+    ):
+        new_retry = super().increment(
+            method=method,
+            url=url,
+            response=response,
+            error=error,
+            _pool=_pool,
+            _stacktrace=_stacktrace,
+        )
+
+        if response is not None and response.status in self.status_forcelist:
+            retry_after = response.headers.get("Retry-After")
+            logging.warning(
+                "HTTP %d from %s; retrying request "
+                "(retries remaining: %s, Retry-After: %s)",
+                response.status,
+                url,
+                new_retry.total,
+                retry_after if retry_after is not None else "not provided",
+            )
+
+        return new_retry
+
+
 def is_fsspec_uri(uri):
     """
     See if uri is something fsspec can handle.
@@ -294,7 +330,7 @@ def download_file(
         session = requests.Session()
         # Configure retry strategy
         # We'll just use a fixed configuration, unless it turns out to need fine-tuning
-        retries = Retry(
+        retries = LoggingRetry(
             total=3,  # Total number of retries
             backoff_factor=2,  # Exponential backoff factor (sleep for 0s, 4s, 8s between retries)
             status_forcelist=[429, 500, 502, 503, 504],  # HTTP status codes to force a retry on
@@ -593,7 +629,7 @@ def download(
         session = requests.Session()
         # Configure retry strategy
         # We'll just use a fixed configuration, unless it turns out to need fine-tuning
-        retries = Retry(
+        retries = LoggingRetry(
             total=3,  # Total number of retries
             backoff_factor=2,  # Exponential backoff factor (sleep for 0s, 4s, 8s between retries)
             status_forcelist=[429, 500, 502, 503, 504],  # HTTP status codes to force a retry on

--- a/pyspedas/utilities/download.py
+++ b/pyspedas/utilities/download.py
@@ -155,7 +155,8 @@ def download_file(
     basic_auth=False,
     nbr_tries=0,
     text_only=None,
-    force_download=False
+    force_download=False,
+    return_text=False,
 ):
     """
     Download a file and return its local path; this function is primarily meant to be called by the download function.
@@ -186,6 +187,9 @@ def download_file(
     force_download : bool, optional
         Flag to indicate if the file should be downloaded even if a local version exists.
         This causes the local version of the file to be overwritten.
+    return_text : bool, optional
+        If True, return the response body as a string without creating a local file.
+        Defaults to False.
 
     Returns
     -------
@@ -350,6 +354,10 @@ def download_file(
         logging.error("Unauthorized: " + url)
         fsrc.close()
         return None
+    elif fsrc.status_code == 200 and return_text:
+        response_text = fsrc.text
+        fsrc.close()
+        return response_text
     elif fsrc.status_code == 200 or (fsrc.status_code == 304 and force_download):
         # this is the main download case
         needs_to_download_file = True
@@ -495,6 +503,7 @@ def download(
     no_wildcards=False,
     text_only=None,
     force_download=False,
+    return_text=False,
 ):
     """
     Download one or more remote files and return their local paths.
@@ -535,6 +544,10 @@ def download(
     force_download : bool, optional
         Flag to indicate if the file should be downloaded even if a local version exists.
         This causes the local version of the file to be overwritten.
+    return_text : bool, optional
+        If True, return the response body as a string without creating a local file.
+        This option supports a single direct URL and does not perform wildcard
+        expansion. Defaults to False.
 
     Cloud Awareness
     ---------------
@@ -545,8 +558,9 @@ def download(
 
     Returns
     -------
-    list of str
-        String list specifying the full local path to all requested files.
+    list of str or str
+        String list specifying the full local path to all requested files. If
+        ``return_text`` is True, return the response body as a string instead.
 
     Examples
     --------
@@ -608,6 +622,10 @@ def download(
     if not isinstance(remote_file, list):
         remote_file = [remote_file]
 
+    if return_text and len(remote_file) != 1:
+        logging.error("return_text=True supports only one remote file")
+        return None
+
     urls = [remote_path + rfile for rfile in remote_file]
 
     for url in urls:
@@ -632,7 +650,7 @@ def download(
 
         if not no_download:
             # expand the wildcards in the url
-            if ("?" in url or "*" in url or regex) and (
+            if not return_text and ("?" in url or "*" in url or regex) and (
                 not no_download and not no_wildcards
             ):
                 if index_table.get(url_base) is not None and not is_fsspec_uri(url):
@@ -790,8 +808,12 @@ def download(
                 session=session,
                 basic_auth=basic_auth,
                 text_only=text_only,
-                force_download=force_download
+                force_download=force_download,
+                return_text=return_text,
             )
+
+            if return_text:
+                return resp_data
 
         if resp_data is not None:
             if not isinstance(resp_data, list):

--- a/pyspedas/utilities/tests/test_utilities_download.py
+++ b/pyspedas/utilities/tests/test_utilities_download.py
@@ -39,13 +39,14 @@ class DownloadTestCases(unittest.TestCase):
         server_thread = threading.Thread(target=server.serve_forever)
         server_thread.start()
         try:
-            result = download(
-                remote_file=(
-                    f"http://127.0.0.1:{server.server_port}/file_names"
-                    "?instrument=mag&level=l2"
-                ),
-                return_text=True,
-            )
+            with self.assertLogs(level="WARNING") as log:
+                result = download(
+                    remote_file=(
+                        f"http://127.0.0.1:{server.server_port}/file_names"
+                        "?instrument=mag&level=l2"
+                    ),
+                    return_text=True,
+                )
         finally:
             server.shutdown()
             server.server_close()
@@ -53,6 +54,9 @@ class DownloadTestCases(unittest.TestCase):
 
         self.assertEqual(result, "mvn_mag_l2_20200101_v01_r01.cdf")
         self.assertEqual(RetryHandler.request_count, 2)
+        self.assertIn("HTTP 429", log.output[0])
+        self.assertIn("retries remaining: 2", log.output[0])
+        self.assertIn("Retry-After: 0", log.output[0])
 
     def test_return_text_rejects_multiple_urls(self):
         with self.assertLogs(level="ERROR") as log:

--- a/pyspedas/utilities/tests/test_utilities_download.py
+++ b/pyspedas/utilities/tests/test_utilities_download.py
@@ -1,5 +1,7 @@
 import os
+import threading
 import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pyspedas
 from pyspedas.utilities.download import download
@@ -11,6 +13,57 @@ themis_remote = CONFIG['remote_data_dir']
 
 
 class DownloadTestCases(unittest.TestCase):
+    def test_return_text_retries_429(self):
+        class RetryHandler(BaseHTTPRequestHandler):
+            request_count = 0
+
+            def do_GET(self):
+                RetryHandler.request_count += 1
+                if RetryHandler.request_count == 1:
+                    self.send_response(429)
+                    self.send_header("Retry-After", "0")
+                    self.end_headers()
+                    return
+
+                body = b"mvn_mag_l2_20200101_v01_r01.cdf"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format, *args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), RetryHandler)
+        server_thread = threading.Thread(target=server.serve_forever)
+        server_thread.start()
+        try:
+            result = download(
+                remote_file=(
+                    f"http://127.0.0.1:{server.server_port}/file_names"
+                    "?instrument=mag&level=l2"
+                ),
+                return_text=True,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join()
+
+        self.assertEqual(result, "mvn_mag_l2_20200101_v01_r01.cdf")
+        self.assertEqual(RetryHandler.request_count, 2)
+
+    def test_return_text_rejects_multiple_urls(self):
+        with self.assertLogs(level="ERROR") as log:
+            result = download(
+                remote_file=["https://example.com/one", "https://example.com/two"],
+                return_text=True,
+            )
+
+        self.assertIsNone(result)
+        self.assertIn("supports only one remote file", log.output[0])
+
     def test_remote_path(self):
         # only specifying remote_path saves the files to the current working directory
         files = download(remote_path='https://spdf.gsfc.nasa.gov/pub/data/psp/sweap/spc/l3/l3i/2019/psp_swp_spc_l3i_20190401_v01.cdf')


### PR DESCRIPTION
Add support for logging retries due to HTTP 429 responses to download() routine.
Add support to return server responses as text rather than creating files to download() routine.
Update MAVEN download code to use download() instead of direct urllib3 calls.
Add tests for 429 retries, return_text, and MAVEN updates.